### PR TITLE
feat: features that were useful when preparing my Berlin 2026 talks

### DIFF
--- a/Demo.lean
+++ b/Demo.lean
@@ -254,6 +254,45 @@ But not {lean +error}`β`.
 end
 ```
 
+# C++ Example
+
+```cpp
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+template <typename T>
+T max_element(const std::vector<T>& v) {
+    return *std::max_element(v.begin(), v.end());
+}
+
+int main() {
+    std::vector<int> nums = {3, 1, 4, 1, 5, 9};
+    std::cout << "Max: " << max_element(nums) << std::endl;
+    return 0;
+}
+```
+
+# Rust Example
+
+```rust
+use std::collections::HashMap;
+
+fn word_count(text: &str) -> HashMap<&str, usize> {
+    let mut counts = HashMap::new();
+    for word in text.split_whitespace() {
+        *counts.entry(word).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn main() {
+    let text = "hello world hello";
+    let counts = word_count(text);
+    println!("{:?}", counts);
+}
+```
+
 # Thank You
 
 That concludes the *VersoSlides* demo.

--- a/Tests/Fragmentize.lean
+++ b/Tests/Fragmentize.lean
@@ -330,3 +330,38 @@ where
 
     testErr "error: unclosed hide"
       (.seq #[kw "def", u " ", id' "foo", u " /- !hide -/ ", id' "bar"])
+
+    ---- Replace: basic inline replace ----
+    testOk "inline replace"
+      (.seq #[kw "def", u " ", id' "foo", u " := ",
+              u "/- !replace ... -/", id' "some_large_term", u " /- !end replace -/"])
+      (.seq #[
+        .hl (.seq #[kw "def", u " ", id' "foo", u " := ", u "..."]),
+      ])
+
+    ---- Replace: replace removes tokens between markers ----
+    testOk "replace removes tokens"
+      (.seq #[kw "def", u " ", id' "foo", u " := ",
+              u "/- !replace ... -/",
+              kw "have", u " ", id' "h", u " := ", id' "sorry", u "\n",
+              u "/- !end replace -/",
+              id' "h"])
+      (.seq #[
+        .hl (.seq #[kw "def", u " ", id' "foo", u " := ", u "..."]),
+        .hl (id' "h")
+      ])
+
+    ---- Replace: replace with multi-word text ----
+    testOk "replace with multi-word text"
+      (.seq #[kw "def", u " ", id' "foo", u " := ",
+              u "/- !replace <large proof> -/", id' "sorry", u " /- !end replace -/"])
+      (.seq #[
+        .hl (.seq #[kw "def", u " ", id' "foo", u " := ", u "<large proof>"]),
+      ])
+
+    ---- Replace errors ----
+    testErr "error: end replace without open"
+      (.seq #[kw "def", u " ", id' "foo", u " /- !end replace -/"])
+
+    testErr "error: unclosed replace"
+      (.seq #[kw "def", u " ", id' "foo", u " /- !replace ... -/ ", id' "bar"])

--- a/VersoSlides.lean
+++ b/VersoSlides.lean
@@ -10,6 +10,7 @@ import VersoSlidesVendored
 import VersoSlides.Render
 import VersoSlides.Directives
 import VersoSlides.InlineLean
+import VersoSlides.ExternalCode
 import VersoSlides.SlideCode
 import VersoSlides.SlideCode.Export
 import VersoSlides.SlideCode.Render

--- a/VersoSlides/Basic.lean
+++ b/VersoSlides/Basic.lean
@@ -109,9 +109,9 @@ public inductive BlockExt where
   /-- Wraps ALL children in a `<div>` with the given attributes. -/
   | wrap (attrs : Array (String × String))
   /-- Elaborated Lean code block with syntax highlighting (fallback when fragmentize fails). -/
-  | leanCode (hlExport : String)
+  | leanCode (hlExport : String) (panel : Bool)
   /-- Fragmentized Lean code block, serialized via {lit}`ExportSlideCode`. -/
-  | slideCode (scExport : String)
+  | slideCode (scExport : String) (panel : Bool)
   /-- External (non-Lean) code block with a language tag for highlight.js. -/
   | externalCode (language : String) (code : String)
 deriving BEq, Repr, Lean.ToJson, Lean.FromJson

--- a/VersoSlides/Basic.lean
+++ b/VersoSlides/Basic.lean
@@ -112,6 +112,8 @@ public inductive BlockExt where
   | leanCode (hlExport : String)
   /-- Fragmentized Lean code block, serialized via {lit}`ExportSlideCode`. -/
   | slideCode (scExport : String)
+  /-- External (non-Lean) code block with a language tag for highlight.js. -/
+  | externalCode (language : String) (code : String)
 deriving BEq, Repr, Lean.ToJson, Lean.FromJson
 
 /-- Custom inline elements for the Slides genre -/

--- a/VersoSlides/ExternalCode.lean
+++ b/VersoSlides/ExternalCode.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+
+import VersoSlides.Basic
+import Verso.Doc.Elab.Monad
+
+/-!
+Code block handlers for external (non-Lean) languages.
+
+These produce `BlockExt.externalCode` blocks whose HTML rendering includes
+a `language-*` class so that the bundled reveal.js highlight.js plugin
+applies syntax highlighting at presentation time.
+-/
+
+open Lean Elab
+open Verso Doc Elab
+open Lean.Doc.Syntax
+
+namespace VersoSlides
+
+/-- Helper that builds a `Block.other (BlockExt.externalCode lang)` term. -/
+private def externalCodeBlock (language : String) (str : StrLit) : DocElabM Term :=
+  ``(Verso.Doc.Block.other (BlockExt.externalCode $(quote language) $(quote str.getString)) #[])
+
+@[code_block]
+def cpp : CodeBlockExpanderOf Unit
+  | (), str => externalCodeBlock "cpp" str
+
+@[code_block]
+def c : CodeBlockExpanderOf Unit
+  | (), str => externalCodeBlock "c" str
+
+@[code_block]
+def rust : CodeBlockExpanderOf Unit
+  | (), str => externalCodeBlock "rust" str
+
+end VersoSlides

--- a/VersoSlides/InlineLean.lean
+++ b/VersoSlides/InlineLean.lean
@@ -22,8 +22,16 @@ open Lean.Doc.Syntax
 
 namespace VersoSlides
 
+/-- Slides-specific code block configuration, extending {name}`LeanBlockConfig` with a panel toggle. -/
+private structure SlidesLeanBlockConfig where
+  inner : LeanBlockConfig
+  panel : Bool
+
+instance : Verso.ArgParse.FromArgs SlidesLeanBlockConfig DocElabM where
+  fromArgs := SlidesLeanBlockConfig.mk <$> Verso.ArgParse.fromArgs <*> .flag `panel true
+
 /-- Callback for `elabCommands`: produces a `Block.other (BlockExt.slideCode ...)` term. -/
-private def toSlidesHighlightedBlock (shouldShow : Bool) (hls : Highlighted) (str : StrLit) :
+private def toSlidesHighlightedBlock (panel : Bool) (shouldShow : Bool) (hls : Highlighted) (str : StrLit) :
     DocElabM Term := do
   if !shouldShow then
     return ← ``(Verso.Doc.Block.concat #[])
@@ -37,7 +45,7 @@ private def toSlidesHighlightedBlock (shouldShow : Bool) (hls : Highlighted) (st
   match fragmentize hls.trim with
   | .ok sc =>
     let exported := scToExport sc
-    ``(Verso.Doc.Block.other (VersoSlides.BlockExt.slideCode $(quote exported)) #[Verso.Doc.Block.code $(quote str.getString)])
+    ``(Verso.Doc.Block.other (VersoSlides.BlockExt.slideCode $(quote exported) $(quote panel)) #[Verso.Doc.Block.code $(quote str.getString)])
   | .error msg =>
     throwErrorAt str.raw msg
 
@@ -167,8 +175,8 @@ where
 
 /-- Elaborated Lean code block for slides (with format data collection). -/
 @[code_block]
-def lean : CodeBlockExpanderOf LeanBlockConfig
-  | config, str => elabCommandsWithFormat config str toSlidesHighlightedBlock
+def lean : CodeBlockExpanderOf SlidesLeanBlockConfig
+  | config, str => elabCommandsWithFormat config.inner str (toSlidesHighlightedBlock config.panel)
 
 /-- Inline elaborated Lean command for slides (with format data collection). -/
 @[role]

--- a/VersoSlides/Render.lean
+++ b/VersoSlides/Render.lean
@@ -125,6 +125,8 @@ instance [Monad m] : GenreHtml Slides m where
           </div>
         </div>
       }}
+    | .externalCode language code =>
+      pure {{ <pre><code class={{s!"language-{language}"}}>{{code}}</code></pre> }}
   inline inlineHtml container contents := do
     match container with
     | .fragment style index =>

--- a/VersoSlides/Render.lean
+++ b/VersoSlides/Render.lean
@@ -258,6 +258,9 @@ private def lightboxJs : String := include_str "../panel/lightbox.js"
 /-- CSS overrides for Verso highlighted code within reveal.js slides. -/
 private def slidesHighlightCss : String := include_str "../panel/slides-highlight.css"
 
+/-- JS that wraps regular Lean comments in styled spans. -/
+private def leanCommentsJs : String := include_str "../panel/lean-comments.js"
+
 /--
 JS that adapts code block styling based on the computed background luminance of each slide. Sets
 {lit}`.slide-light-bg` on light sections (toggles CSS variable palette) and applies appropriate code
@@ -324,6 +327,7 @@ def renderFullHtml (config : Config) (title : String) (slidesBody : Html) : Html
       <script src={{s!"{libPrefix}/tippy.js"}}></script>
       <script src={{s!"{libPrefix}/tippy-panel-filter.js"}}></script>
       <script src={{s!"{libPrefix}/highlighting.js"}}></script>
+      <script src={{s!"{libPrefix}/lean-comments.js"}}></script>
       <script src={{s!"{libPrefix}/code-block-bg.js"}}></script>
       <script src={{s!"{libPrefix}/pretty.js"}}></script>
       <script src={{s!"{libPrefix}/panel.js"}}></script>
@@ -381,6 +385,7 @@ def writeVendoredAssets (outputDir : System.FilePath) (theme : String) : IO Unit
   writeFileWithDirs (libDir / "slides-highlight.css") slidesHighlightCss
   writeFileWithDirs (libDir / "panel.css") slideCodePanelCss
   writeFileWithDirs (libDir / "tippy-panel-filter.js") tippyPanelFilterJs
+  writeFileWithDirs (libDir / "lean-comments.js") leanCommentsJs
   writeFileWithDirs (libDir / "code-block-bg.js") codeBlockBgJs
   writeFileWithDirs (libDir / "pretty.js") prettyJs
   writeFileWithDirs (libDir / "panel.js") slideCodePanelJs

--- a/VersoSlides/Render.lean
+++ b/VersoSlides/Render.lean
@@ -99,32 +99,38 @@ instance [Monad m] : GenreHtml Slides m where
     | .wrap attrs =>
       let inner ← contents.mapM blockHtml
       pure (.tag "div" attrs (.seq inner))
-    | .slideCode scExport =>
+    | .slideCode scExport panel =>
       let sc := scFromExport! scExport
       let codeHtml ← pure {{ <code class="hl lean block"> {{ ← sc.toHtml (g := Slides) }} </code> }}
-      pure {{
-        <div class="code-with-panel">
-          {{codeHtml}}
-          <div class="panel-divider"></div>
-          <div class="panel-cell">
-            <div class="info-panel"></div>
+      if panel then
+        pure {{
+          <div class="code-with-panel">
+            {{codeHtml}}
+            <div class="panel-divider"></div>
+            <div class="panel-cell">
+              <div class="info-panel"></div>
+            </div>
           </div>
-        </div>
-      }}
-    | .leanCode hlExport =>
+        }}
+      else
+        pure codeHtml
+    | .leanCode hlExport panel =>
       let hl := (hlFromExport! hlExport).trim
       let codeHtml ← match fragmentize hl with
         | .error _msg => hl.blockHtml (g := Slides) "lean"
         | .ok sc => pure {{ <code class="hl lean block"> {{ ← sc.toHtml (g := Slides) }} </code> }}
-      pure {{
-        <div class="code-with-panel">
-          {{codeHtml}}
-          <div class="panel-divider"></div>
-          <div class="panel-cell">
-            <div class="info-panel"></div>
+      if panel then
+        pure {{
+          <div class="code-with-panel">
+            {{codeHtml}}
+            <div class="panel-divider"></div>
+            <div class="panel-cell">
+              <div class="info-panel"></div>
+            </div>
           </div>
-        </div>
-      }}
+        }}
+      else
+        pure codeHtml
     | .externalCode language code =>
       pure {{ <pre><code class={{s!"language-{language}"}}>{{code}}</code></pre> }}
   inline inlineHtml container contents := do

--- a/VersoSlides/SlideCode.lean
+++ b/VersoSlides/SlideCode.lean
@@ -467,6 +467,8 @@ private inductive InlineMarkerKind where
   | fragmentEnd
   | hideStart
   | hideEnd
+  | replaceStart
+  | replaceEnd
 
 /-- A segment from splitting around inline marker comments. -/
 private inductive TextSegment where
@@ -475,6 +477,8 @@ private inductive TextSegment where
   | inlineEnd
   | hideStart
   | hideEnd
+  | replaceStart (text : String)
+  | replaceEnd
 
 /-- Parses inline fragment wrapper arguments. -/
 private def parseInlineWrapper (s : String) : FragmentData :=
@@ -522,7 +526,10 @@ private def findInlineMarker (haystack : String) : Option (InlineMarkerKind × N
           let (probe, probeLen) := skipWs (probe.drop 5) (probeLen + 5)
           if probe.startsWith "-/" then
             return some (.hideStart, ch, ch + probeLen + 2)
-        -- Check for !end (fragment | hide) ... closing comment
+        -- Check for !replace (start marker — does not consume to comment close)
+        if probe.startsWith "!replace" then
+          return some (.replaceStart, ch, ch + probeLen + "!replace".length)
+        -- Check for !end (fragment | hide | replace) ... closing comment
         if probe.startsWith "!end" then
           let afterEnd := probeLen + 4
           let (probe, probeLen) := skipWs (probe.drop 4) afterEnd
@@ -535,6 +542,10 @@ private def findInlineMarker (haystack : String) : Option (InlineMarkerKind × N
               let (probe, probeLen) := skipWs (probe.drop 4) (probeLen + 4)
               if probe.startsWith "-/" then
                 return some (.hideEnd, ch, ch + probeLen + 2)
+            if probe.startsWith "replace" then
+              let (probe, probeLen) := skipWs (probe.drop 7) (probeLen + 7)
+              if probe.startsWith "-/" then
+                return some (.replaceEnd, ch, ch + probeLen + 2)
     slice := slice.drop 1
     ch := ch + 1
   return none
@@ -551,6 +562,16 @@ where
       let markerContent := charSlice remaining afterKw (afterKw + closeOff)
       let wrapper := parseInlineWrapper markerContent.trimAscii.toString
       (acc.push (.inlineStart wrapper), charSlice remaining (afterKw + closeOff + 2) remaining.length |>.copy)
+    | none =>
+      (acc.push (.plain remaining), "")
+
+  processReplaceMarker (remaining : String) (si afterKw : Nat) (acc : Array TextSegment) :
+      Array TextSegment × String :=
+    let acc := if si > 0 then acc.push (.plain (remaining.take si).copy) else acc
+    match findSubstr (charSlice remaining afterKw remaining.length).copy "-/" with
+    | some closeOff =>
+      let text := (charSlice remaining afterKw (afterKw + closeOff)).trimAscii.toString
+      (acc.push (.replaceStart text), charSlice remaining (afterKw + closeOff + 2) remaining.length |>.copy)
     | none =>
       (acc.push (.plain remaining), "")
 
@@ -575,6 +596,12 @@ where
         go remaining acc
       | some (.hideEnd, offset, afterEnd) =>
         let (acc, remaining) := emitAt remaining offset afterEnd .hideEnd acc
+        go remaining acc
+      | some (.replaceStart, offset, afterKw) =>
+        let (acc, remaining) := processReplaceMarker remaining offset afterKw acc
+        go remaining acc
+      | some (.replaceEnd, offset, afterEnd) =>
+        let (acc, remaining) := emitAt remaining offset afterEnd .replaceEnd acc
         go remaining acc
 
 /-- Processes plain text lines for line-level magic comments. -/
@@ -631,6 +658,14 @@ private def processSegment (st : FragState) (seg : TextSegment) (isText : Bool) 
   | .hideEnd =>
     if st.hideDepth == 0 then
       .error "/- !end hide -/ without matching /- !hide -/"
+    else
+      .ok { st with hideDepth := st.hideDepth - 1 }
+  | .replaceStart replacement =>
+    let st := st.pushSC (.hl (.unparsed replacement))
+    .ok { st with hideDepth := st.hideDepth + 1 }
+  | .replaceEnd =>
+    if st.hideDepth == 0 then
+      .error "/- !end replace -/ without matching /- !replace -/"
     else
       .ok { st with hideDepth := st.hideDepth - 1 }
 
@@ -707,7 +742,7 @@ public def fragmentize (hl : Highlighted) : Except String SlideCode := do
   if !finalSt.openInlineFragments.isEmpty then
     throw "Unclosed inline fragment (/- !fragment -/ without /- !end fragment -/)"
   if finalSt.hideDepth > 0 then
-    throw "Unclosed hide region (/- !hide -/ without /- !end hide -/)"
+    throw "Unclosed hide/replace region (/- !hide -/ or /- !replace -/ without matching end marker)"
   -- Emit any pending command output before closing
   let finalSt := match finalSt.pendingCommandOutput with
     | some info => { finalSt.pushSC (.commandOutput info) with pendingCommandOutput := none }

--- a/panel/code-block-bg.js
+++ b/panel/code-block-bg.js
@@ -52,7 +52,8 @@ function updateSlides() {
                 if (panelCell) panelCell.style.background = codeBg;
             }
         });
-        section.querySelectorAll('pre > code[class*="language-"]').forEach(function (el) {
+        section.querySelectorAll("pre").forEach(function (el) {
+            if (el.closest(".code-with-panel")) return;
             el.style.background = codeBg;
         });
     });

--- a/panel/code-block-bg.js
+++ b/panel/code-block-bg.js
@@ -52,6 +52,9 @@ function updateSlides() {
                 if (panelCell) panelCell.style.background = codeBg;
             }
         });
+        section.querySelectorAll('pre > code[class*="language-"]').forEach(function (el) {
+            el.style.background = codeBg;
+        });
     });
 }
 Reveal.on("ready", updateSlides);

--- a/panel/lean-comments.js
+++ b/panel/lean-comments.js
@@ -1,0 +1,96 @@
+// @ts-check
+/* Post-process Lean code blocks to style comments.
+   Regular comments (-- …, /- … -/) are not tokenized by SubVerso;
+   they end up as plain text inside <span class="inter-text"> elements.
+   This script wraps comment text in <span class="lean-comment"> so CSS
+   can give them a distinct color. */
+(function () {
+    "use strict";
+
+    /** Finds the end of a /- … -/ block comment, handling nesting. */
+    function findBlockEnd(text, start) {
+        var depth = 0;
+        var i = start;
+        while (i < text.length) {
+            if (i + 1 < text.length && text[i] === "/" && text[i + 1] === "-") {
+                depth++;
+                i += 2;
+            } else if (i + 1 < text.length && text[i] === "-" && text[i + 1] === "/") {
+                depth--;
+                i += 2;
+                if (depth === 0) return i;
+            } else {
+                i++;
+            }
+        }
+        return text.length;
+    }
+
+    /**
+     * Splits text into segments, tagging comment regions.
+     * @returns {Array<{text: string, isComment: boolean}>|null}
+     */
+    function parseComments(text) {
+        var segments = [];
+        var i = 0;
+        var plainStart = 0;
+        var found = false;
+
+        while (i < text.length) {
+            // Block comment  /- … -/  (checked first so /-- is handled as block)
+            if (i + 1 < text.length && text[i] === "/" && text[i + 1] === "-") {
+                if (i > plainStart) segments.push({ text: text.slice(plainStart, i), isComment: false });
+                var end = findBlockEnd(text, i);
+                segments.push({ text: text.slice(i, end), isComment: true });
+                i = end;
+                plainStart = i;
+                found = true;
+                continue;
+            }
+            // Line comment  -- …
+            if (i + 1 < text.length && text[i] === "-" && text[i + 1] === "-") {
+                if (i > plainStart) segments.push({ text: text.slice(plainStart, i), isComment: false });
+                var eol = text.indexOf("\n", i);
+                var end = eol === -1 ? text.length : eol;
+                segments.push({ text: text.slice(i, end), isComment: true });
+                i = end;
+                plainStart = i;
+                found = true;
+                continue;
+            }
+            i++;
+        }
+
+        if (!found) return null;
+        if (plainStart < text.length) segments.push({ text: text.slice(plainStart), isComment: false });
+        return segments;
+    }
+
+    /** Replaces text nodes inside an inter-text span with comment-wrapped spans. */
+    function processElement(el) {
+        var text = el.textContent;
+        if (text.indexOf("--") === -1 && text.indexOf("/-") === -1) return;
+
+        var segments = parseComments(text);
+        if (!segments) return;
+
+        el.textContent = "";
+        for (var k = 0; k < segments.length; k++) {
+            var seg = segments[k];
+            if (seg.isComment) {
+                var span = document.createElement("span");
+                span.className = "lean-comment";
+                span.textContent = seg.text;
+                el.appendChild(span);
+            } else {
+                el.appendChild(document.createTextNode(seg.text));
+            }
+        }
+    }
+
+    function run() {
+        document.querySelectorAll(".hl.lean .inter-text").forEach(processElement);
+    }
+
+    Reveal.on("ready", run);
+})();

--- a/panel/slides-highlight.css
+++ b/panel/slides-highlight.css
@@ -7,7 +7,7 @@
     padding: 0.6em 0.8em;
     margin: 0.5em auto;
     box-shadow: 0px 5px 15px rgba(0, 0, 0, 0.15);
-    width: fit-content;
+    width: 95%;
     max-width: 95%;
     overflow-x: auto;
 }

--- a/panel/slides-highlight.css
+++ b/panel/slides-highlight.css
@@ -144,8 +144,9 @@
 /* ── Non-Lean code blocks (with or without language tag) ── */
 /* Match the same box styling as Lean code blocks */
 .reveal pre:not(.code-with-panel pre) {
+    box-sizing: border-box;
     margin: 0.5em auto;
-    width: fit-content;
+    width: 95%;
     max-width: 95%;
     box-shadow: 0px 5px 15px rgba(0, 0, 0, 0.15);
     border-radius: 6px;

--- a/panel/slides-highlight.css
+++ b/panel/slides-highlight.css
@@ -131,16 +131,17 @@
 /* Match the same box styling as Lean code blocks */
 .reveal pre:has(> code[class*="language-"]) {
     margin: 0.5em auto;
-    width: fit-content;
+    width: 95%;
     max-width: 95%;
     box-shadow: 0px 5px 15px rgba(0, 0, 0, 0.15);
     border-radius: 6px;
+    font-size: 0.55em;
+    line-height: 1.45;
 }
 .reveal pre > code[class*="language-"] {
     display: block;
     text-align: left;
-    font-size: 0.55em;
-    line-height: 1.45;
+    font-size: inherit;
     padding: 0.6em 0.8em;
     border-radius: 6px;
     overflow-x: auto;

--- a/panel/slides-highlight.css
+++ b/panel/slides-highlight.css
@@ -1,4 +1,5 @@
 .reveal code.hl.lean.block {
+    box-sizing: border-box;
     display: block;
     text-align: left;
     font-size: 0.55em;

--- a/panel/slides-highlight.css
+++ b/panel/slides-highlight.css
@@ -127,6 +127,100 @@
     color: inherit;
 }
 
+/* ── External (non-Lean) code blocks ── */
+/* Match the same box styling as Lean code blocks */
+.reveal pre:has(> code[class*="language-"]) {
+    margin: 0.5em auto;
+    width: fit-content;
+    max-width: 95%;
+    box-shadow: 0px 5px 15px rgba(0, 0, 0, 0.15);
+    border-radius: 6px;
+}
+.reveal pre > code[class*="language-"] {
+    display: block;
+    text-align: left;
+    font-size: 0.55em;
+    line-height: 1.45;
+    padding: 0.6em 0.8em;
+    border-radius: 6px;
+    overflow-x: auto;
+}
+/* Override monokai: transparent background so slide bg shows through */
+.reveal pre > code.hljs {
+    background: none;
+}
+/* ── highlight.js token colors — match Verso palette (dark slides) ── */
+.reveal .hljs-keyword,
+.reveal .hljs-selector-tag,
+.reveal .hljs-literal {
+    color: var(--verso-code-keyword-color);
+    font-weight: normal;
+}
+.reveal .hljs-built_in,
+.reveal .hljs-type,
+.reveal .hljs-title,
+.reveal .hljs-section,
+.reveal .hljs-selector-id {
+    color: var(--verso-code-const-color);
+    font-weight: normal;
+}
+.reveal .hljs-variable,
+.reveal .hljs-template-variable,
+.reveal .hljs-attr,
+.reveal .hljs-params,
+.reveal .hljs-name,
+.reveal .hljs-tag {
+    color: var(--verso-code-var-color);
+    font-weight: normal;
+}
+.reveal .hljs-string,
+.reveal .hljs-bullet,
+.reveal .hljs-subst,
+.reveal .hljs-addition {
+    color: #98c379;
+}
+.reveal .hljs-number {
+    color: #d19a66;
+}
+.reveal .hljs-comment,
+.reveal .hljs-quote,
+.reveal .hljs-deletion,
+.reveal .hljs-meta {
+    color: #7f848e;
+}
+.reveal .hljs-symbol,
+.reveal .hljs-regexp,
+.reveal .hljs-link {
+    color: #56b6c2;
+}
+.reveal .hljs-emphasis {
+    font-style: italic;
+}
+.reveal .hljs-strong {
+    font-weight: bold;
+}
+/* Light-slide overrides for highlight.js tokens */
+.reveal section.slide-light-bg .hljs-string,
+.reveal section.slide-light-bg .hljs-bullet,
+.reveal section.slide-light-bg .hljs-subst,
+.reveal section.slide-light-bg .hljs-addition {
+    color: #50a14f;
+}
+.reveal section.slide-light-bg .hljs-number {
+    color: #986801;
+}
+.reveal section.slide-light-bg .hljs-comment,
+.reveal section.slide-light-bg .hljs-quote,
+.reveal section.slide-light-bg .hljs-deletion,
+.reveal section.slide-light-bg .hljs-meta {
+    color: #a0a1a7;
+}
+.reveal section.slide-light-bg .hljs-symbol,
+.reveal section.slide-light-bg .hljs-regexp,
+.reveal section.slide-light-bg .hljs-link {
+    color: #0184bc;
+}
+
 /* slide-click-only: always visible, but participates in fragment ordering */
 .reveal .fragment.slide-click-only {
     opacity: 1;

--- a/panel/slides-highlight.css
+++ b/panel/slides-highlight.css
@@ -127,9 +127,9 @@
     color: inherit;
 }
 
-/* ── External (non-Lean) code blocks ── */
+/* ── Non-Lean code blocks (with or without language tag) ── */
 /* Match the same box styling as Lean code blocks */
-.reveal pre:has(> code[class*="language-"]) {
+.reveal pre:not(.code-with-panel pre) {
     margin: 0.5em auto;
     width: 95%;
     max-width: 95%;
@@ -137,14 +137,14 @@
     border-radius: 6px;
     font-size: 0.55em;
     line-height: 1.45;
+    text-align: left;
+    padding: 0.6em 0.8em;
+    overflow-x: auto;
 }
 .reveal pre > code[class*="language-"] {
     display: block;
-    text-align: left;
     font-size: inherit;
-    padding: 0.6em 0.8em;
-    border-radius: 6px;
-    overflow-x: auto;
+    padding: 0;
 }
 /* Override monokai: transparent background so slide bg shows through */
 .reveal pre > code.hljs {

--- a/panel/slides-highlight.css
+++ b/panel/slides-highlight.css
@@ -44,6 +44,12 @@
     word-wrap: break-word;
     overflow-wrap: break-word;
 }
+/* Lean comment styling (regular and doc comments) */
+.hl.lean .lean-comment,
+.hl.lean .doc-comment {
+    color: var(--verso-code-comment-color);
+    font-style: italic;
+}
 /* Verso token colors — purple/blue/teal, colorblind-safe.
    Literals and unknown tokens inherit the slide text color. */
 .hl.lean .literal,
@@ -55,12 +61,14 @@
     --verso-code-keyword-color: #c678dd;
     --verso-code-const-color: #61afef;
     --verso-code-var-color: #56d4c0;
+    --verso-code-comment-color: #7f848e;
 }
 /* Light slides — set per-section by code-block-bg.js */
 .reveal section.slide-light-bg {
     --verso-code-keyword-color: #8839a0;
     --verso-code-const-color: #1a5fb4;
     --verso-code-var-color: #1a7a6a;
+    --verso-code-comment-color: #a0a1a7;
 }
 /* Adapt hover/binding highlight colors to the reveal.js theme */
 .reveal .hl.lean .token.binding-hl,
@@ -104,26 +112,32 @@
 .reveal .fragment.highlight-red.visible .keyword,
 .reveal .fragment.highlight-red.visible .literal,
 .reveal .fragment.highlight-red.visible .unknown,
+.reveal .fragment.highlight-red.visible .lean-comment,
 .reveal .fragment.highlight-green.visible .token,
 .reveal .fragment.highlight-green.visible .keyword,
 .reveal .fragment.highlight-green.visible .literal,
 .reveal .fragment.highlight-green.visible .unknown,
+.reveal .fragment.highlight-green.visible .lean-comment,
 .reveal .fragment.highlight-blue.visible .token,
 .reveal .fragment.highlight-blue.visible .keyword,
 .reveal .fragment.highlight-blue.visible .literal,
 .reveal .fragment.highlight-blue.visible .unknown,
+.reveal .fragment.highlight-blue.visible .lean-comment,
 .reveal .fragment.highlight-current-red.current-fragment .token,
 .reveal .fragment.highlight-current-red.current-fragment .keyword,
 .reveal .fragment.highlight-current-red.current-fragment .literal,
 .reveal .fragment.highlight-current-red.current-fragment .unknown,
+.reveal .fragment.highlight-current-red.current-fragment .lean-comment,
 .reveal .fragment.highlight-current-green.current-fragment .token,
 .reveal .fragment.highlight-current-green.current-fragment .keyword,
 .reveal .fragment.highlight-current-green.current-fragment .literal,
 .reveal .fragment.highlight-current-green.current-fragment .unknown,
+.reveal .fragment.highlight-current-green.current-fragment .lean-comment,
 .reveal .fragment.highlight-current-blue.current-fragment .token,
 .reveal .fragment.highlight-current-blue.current-fragment .keyword,
 .reveal .fragment.highlight-current-blue.current-fragment .literal,
-.reveal .fragment.highlight-current-blue.current-fragment .unknown {
+.reveal .fragment.highlight-current-blue.current-fragment .unknown,
+.reveal .fragment.highlight-current-blue.current-fragment .lean-comment {
     color: inherit;
 }
 

--- a/panel/slides-highlight.css
+++ b/panel/slides-highlight.css
@@ -145,7 +145,7 @@
 /* Match the same box styling as Lean code blocks */
 .reveal pre:not(.code-with-panel pre) {
     margin: 0.5em auto;
-    width: 95%;
+    width: fit-content;
     max-width: 95%;
     box-shadow: 0px 5px 15px rgba(0, 0, 0, 0.15);
     border-radius: 6px;


### PR DESCRIPTION
This is all written by Claude; I have not looked at the code.

* Code blocks with highlighting for C++ and Rust
* A lean -panel option which hides the infoview from Lean code blocks
* A /- !replace abc -/ code /- !end replace -/ syntax that replaces code with abc. I use this a lot with abc = ... to save space on slides
* Syntax highlighting for comments (very hacky workaround for https://github.com/leanprover/verso/issues/274)