### PR TITLE
feat: support reveal.js's frontend-based highlighting

### DIFF
--- a/Demo.lean
+++ b/Demo.lean
@@ -254,6 +254,26 @@ But not {lean +error}`β`.
 end
 ```
 
+# Other Languages
+
+```code rust
+fn main() {
+    let nums = vec![3, 1, 4, 1, 5, 9];
+    let max = nums.iter().max().unwrap();
+    println!("Max: {max}");
+}
+```
+
+```code "c++"
+#include <iostream>
+#include <vector>
+
+int main() {
+    std::vector<int> v = {1, 2, 3};
+    for (auto x : v) std::cout << x << "\n";
+}
+```
+
 # Thank You
 
 That concludes the *VersoSlides* demo.

--- a/TestFixtures/Code.lean
+++ b/TestFixtures/Code.lean
@@ -54,3 +54,14 @@ def growDef : Nat := 1
 -- !fragment highlight-current-red
 def redDef : Nat := 2
 ```
+
+# Rust Code
+
+```code rust
+fn main() {
+    let nums = vec![3, 1, 4, 1, 5];
+    for n in &nums {
+        println!("{n}");
+    }
+}
+```

--- a/VersoSlides.lean
+++ b/VersoSlides.lean
@@ -9,6 +9,7 @@ import VersoSlides.Attributes
 import VersoSlidesVendored
 import VersoSlides.Render
 import VersoSlides.Directives
+import VersoSlides.OtherLanguages
 import VersoSlides.InlineLean
 import VersoSlides.SlideCode
 import VersoSlides.SlideCode.Export

--- a/VersoSlides/Basic.lean
+++ b/VersoSlides/Basic.lean
@@ -112,6 +112,8 @@ public inductive BlockExt where
   | leanCode (hlExport : String)
   /-- Fragmentized Lean code block, serialized via {lit}`ExportSlideCode`. -/
   | slideCode (scExport : String)
+  /-- Non-Lean code block with a language tag for highlight.js. -/
+  | otherLanguage (language : String) (code : String)
 deriving BEq, Repr, Lean.ToJson, Lean.FromJson
 
 /-- Custom inline elements for the Slides genre -/

--- a/VersoSlides/OtherLanguages.lean
+++ b/VersoSlides/OtherLanguages.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+
+import VersoSlides.Basic
+import Verso.Doc.Elab.Monad
+
+/-!
+Code block handler for other (non-Lean) languages.
+
+Produces `BlockExt.otherLanguage` blocks whose HTML rendering includes
+a `language-*` class so that the bundled reveal.js highlight.js plugin
+applies syntax highlighting at presentation time.
+
+Usage:
+````
+```code rust
+fn main() { println!("hello"); }
+```
+
+```code "c++"
+#include <iostream>
+int main() { std::cout << "hello"; }
+```
+````
+The language name can be an identifier (`rust`, `python`) or a string
+(`"c++"`, `"c#"`).
+-/
+
+open Lean Elab
+open Verso Doc Elab
+open Lean.Doc.Syntax
+
+namespace VersoSlides
+
+/-- A language name parsed from either an identifier or a string literal. -/
+private def langName : Verso.ArgParse.ValDesc DocElabM String where
+  description := "a language name"
+  signature := { ident := true, string := true, num := false }
+  get
+    | .name x => pure (x.getId.toString (escape := false))
+    | .str s => pure s.getString
+    | other => throwError "Expected language name (identifier or string), got {repr other}"
+
+/-- Configuration for the `code` block expander: a required language name. -/
+private structure CodeConfig where
+  language : String
+
+instance : Verso.ArgParse.FromArgs CodeConfig DocElabM where
+  fromArgs := CodeConfig.mk <$> .positional `language langName
+
+/--
+Uses `reveal.js`'s built-in syntax highlighting for code.
+-/
+@[code_block]
+def code : CodeBlockExpanderOf CodeConfig
+  | config, str =>
+    ``(Verso.Doc.Block.other (BlockExt.otherLanguage $(quote config.language) $(quote str.getString)) #[])
+
+end VersoSlides

--- a/VersoSlides/Render.lean
+++ b/VersoSlides/Render.lean
@@ -125,6 +125,8 @@ instance [Monad m] : GenreHtml Slides m where
           </div>
         </div>
       }}
+    | .otherLanguage language code =>
+      pure {{ <pre><code class=s!"language-{language}">{{code}}</code></pre> }}
   inline inlineHtml container contents := do
     match container with
     | .fragment style index =>

--- a/browser-tests/test_other_languages.py
+++ b/browser-tests/test_other_languages.py
@@ -1,0 +1,43 @@
+"""Browser tests for non-Lean code blocks (highlight.js integration)."""
+
+from playwright.sync_api import expect, Page
+
+
+class TestHighlightJs:
+    def test_rust_code_block_highlighted(self, code_url: str, page: Page):
+        """highlight.js should inject hljs-* spans into the Rust code block."""
+        # Rust Code is slide index 5
+        page.goto(f"{code_url}/index.html#/5")
+        page.wait_for_load_state("networkidle")
+        page.wait_for_timeout(1000)
+
+        block = page.locator("pre > code.language-rust")
+        expect(block).to_be_visible()
+
+        # highlight.js adds class "hljs" to the <code> element after processing
+        expect(block).to_have_class("language-rust hljs")
+
+        # Should contain highlighted keyword tokens (fn, let, for, in)
+        keywords = block.locator(".hljs-keyword")
+        assert keywords.count() >= 3
+
+        # Should contain highlighted string tokens (the format string)
+        strings = block.locator(".hljs-string")
+        assert strings.count() >= 1
+
+        # Should contain the original source text
+        text = block.inner_text()
+        assert "fn main()" in text
+        assert "vec!" in text
+
+    def test_rust_block_has_box_styling(self, code_url: str, page: Page):
+        """Rust code blocks should have box styling (border-radius, shadow)."""
+        page.goto(f"{code_url}/index.html#/5")
+        page.wait_for_load_state("networkidle")
+        page.wait_for_timeout(1000)
+
+        pre = page.locator("pre:has(> code.language-rust)")
+        expect(pre).to_be_visible()
+
+        border_radius = pre.evaluate("el => getComputedStyle(el).borderRadius")
+        assert border_radius == "6px"

--- a/panel/code-block-bg.js
+++ b/panel/code-block-bg.js
@@ -52,6 +52,10 @@ function updateSlides() {
                 if (panelCell) panelCell.style.background = codeBg;
             }
         });
+        section.querySelectorAll("pre").forEach(function (el) {
+            if (el.closest(".code-with-panel")) return;
+            el.style.background = codeBg;
+        });
     });
 }
 Reveal.on("ready", updateSlides);

--- a/panel/slides-highlight.css
+++ b/panel/slides-highlight.css
@@ -127,6 +127,31 @@
     color: inherit;
 }
 
+/* ── Non-Lean code blocks (highlight.js) ── */
+/* Match the Lean code block box styling; token colors come from monokai.css */
+.reveal pre:not(.code-with-panel pre) {
+    box-sizing: border-box;
+    margin: 0.5em auto;
+    width: fit-content;
+    max-width: 95%;
+    box-shadow: 0px 5px 15px rgba(0, 0, 0, 0.15);
+    border-radius: 6px;
+    font-size: 0.55em;
+    line-height: 1.45;
+    text-align: left;
+    padding: 0.6em 0.8em;
+    overflow-x: auto;
+}
+.reveal pre > code[class*="language-"] {
+    display: block;
+    font-size: inherit;
+    padding: 0;
+}
+/* Override monokai: transparent background so slide bg shows through */
+.reveal pre > code.hljs {
+    background: none;
+}
+
 /* slide-click-only: always visible, but participates in fragment ordering */
 .reveal .fragment.slide-click-only {
     opacity: 1;


### PR DESCRIPTION
This allows for syntax highlighting of other languages.