### PR TITLE
fix: correctly associate #eval output with the command

### DIFF
--- a/TestFixtures/Code.lean
+++ b/TestFixtures/Code.lean
@@ -76,6 +76,51 @@ def commented : Nat := 42
 /- A block comment -/
 ```
 
+# Eval Ordering
+
+```lean
+#eval s!"It is {1 + 1} first"
+def evalMiddle := 5
+#eval s!"Then it is {2 + 2}"
+#eval s!"Then it is {4 + 4}"
+```
+
+# Eval Multiline
+
+```lean
+#eval 1 +
+
+  2 +
+
+3
+```
+
+# Check Ordering
+
+```lean
+def checkTarget := 42
+#check checkTarget
+def checkMiddle := "hi"
+#check checkMiddle
+```
+
+# Print Ordering
+
+```lean
+def printTarget := 100
+#print printTarget
+def printMiddle := true
+#print printMiddle
+```
+
+# Reduce Ordering
+
+```lean
+#reduce 2 + 3
+def reduceMiddle := 10
+#reduce 10 * 2
+```
+
 # Rust Code
 
 ```code rust

--- a/VersoSlides/InlineLean.lean
+++ b/VersoSlides/InlineLean.lean
@@ -22,6 +22,44 @@ open Lean.Doc.Syntax
 
 namespace VersoSlides
 
+/-- Syntax node kinds whose output should be rendered inline after the command. -/
+private def queryCommandKinds : Array SyntaxNodeKind :=
+  open Lean.Parser.Command in
+  #[``eval, ``check, ``print, ``reduceCmd]
+
+/--
+Returns `true` if `stx` contains a query command (e.g. `#eval`, `#check`)
+anywhere in its syntax tree, accounting for wrappers like `open ... in`.
+-/
+private def isQueryCommand (stx : Syntax) : Bool :=
+  (stx.find? (queryCommandKinds.contains ·.getKind)).isSome
+
+/-- Token strings for query commands (used to find them in `Highlighted` trees). -/
+private def queryCommandTokens : Array String := #["#check", "#eval", "#print", "#reduce"]
+
+/-- Returns `true` if `hl` contains a query command keyword token anywhere in its tree. -/
+private partial def containsQueryToken : Highlighted → Bool
+  | .token tok => tok.kind matches .keyword .. && queryCommandTokens.contains tok.content
+  | .seq xs => xs.any containsQueryToken
+  | .span _ x | .tactics _ _ _ x => containsQueryToken x
+  | _ => false
+
+/--
+For a query command's highlighted code, find spans that contain a query command
+token and collect their info-severity messages as `point` nodes to append.
+The original tree is left intact (spans keep their info for diagnostic markers).
+-/
+private partial def collectQueryOutput : Highlighted → Array Highlighted
+  | .span info x =>
+    if containsQueryToken x then
+      info.filterMap fun (kind, msg) =>
+        if kind == .info then some (.point kind msg) else none
+    else
+      collectQueryOutput x
+  | .seq xs => xs.foldl (init := #[]) fun acc x => acc ++ collectQueryOutput x
+  | .tactics _ _ _ x => collectQueryOutput x
+  | _ => #[]
+
 /-- Slides-specific code block configuration, extending {name}`LeanBlockConfig` with a panel toggle. -/
 private structure SlidesLeanBlockConfig extends LeanBlockConfig where
   panel : Bool
@@ -132,8 +170,14 @@ def elabCommandsWithFormat (config : LeanBlockConfig) (str : StrLit)
       let nonSilentMsgs := cmdState.messages.toArray.filter (!·.isSilent)
       let mut lastPos : String.Pos.Raw := str.raw.getPos? |>.getD 0
       for cmd in cmds do
-        hls := hls ++ (← highlightIncludingUnparsed cmd nonSilentMsgs cmdState.infoState.trees (startPos? := lastPos) (collectFormat := true))
+        let cmdHl ← highlightIncludingUnparsed cmd nonSilentMsgs cmdState.infoState.trees (startPos? := lastPos) (collectFormat := true)
         lastPos := (cmd.getTrailingTailPos?).getD lastPos
+        -- For query commands (#eval, #check, etc.), extract output messages from
+        -- the highlighted spans and place them as point nodes after the command.
+        hls := hls ++ cmdHl
+        if isQueryCommand cmd then
+          for p in collectQueryOutput cmdHl do
+            hls := hls ++ p
 
       toHighlightedLeanContent config.show hls str
     finally

--- a/VersoSlides/SlideCode.lean
+++ b/VersoSlides/SlideCode.lean
@@ -141,8 +141,6 @@ private structure FragState where
   pendingFragments : Array FragmentData
   activeLineFragment : Option LineFragInfo
   openInlineFragments : Array InlineFragInfo
-  pendingCommandOutput : Option (Array (Span.Kind × MessageContents Highlighted))
-  insideQuerySpan : Bool
   hideDepth : Nat := 0
 
 
@@ -196,9 +194,6 @@ private def findSubstr (haystack needle : String) : Option Nat := Id.run do
     slice := slice.drop 1
     ch := ch + 1
   return none
-
-/-- Known “query commands” whose output is rendered inline. -/
-private def queryCommands : Array String := #["#check", "#eval", "#print", "#reduce"]
 
 /--
 Finds the last newline in a {name}`SlideCode` and splits into (before-including-newline, after-newline).
@@ -625,11 +620,6 @@ private def processPlainLines (st : FragState) (s : String) (isText : Bool) : Ex
     else if let some (caretCol, index) := parseClickComment line then
       st ← st.resolveClickOnCurrent caretCol index
     else
-      if let some cmdInfo := st.pendingCommandOutput then
-        if line == "\n" || (line.startsWith Char.isWhitespace) then
-          st := st.pushSC (.commandOutput cmdInfo)
-          st := { st with pendingCommandOutput := none }
-
       st := st.pushSC (mkLeaf line.toString)
   return st
 
@@ -676,55 +666,36 @@ and then line-level magic comments.
 private def processTextNode (st : FragState) (s : String) (isText : Bool) : Except String FragState :=
   (splitInlineMarkers s).foldlM (init := st) fun acc seg => processSegment acc seg isText
 
-/-- Finds the first {name}`span` context in a context stack (searching from top). -/
-private def findSpanInfo (ctxStack : Array HlCtx) : Option (Array (Span.Kind × MessageContents Highlighted)) :=
-  ctxStack.reverse.findSome? fun
-    | .span info => some info
-    | _ => none
-
 /-- Main worklist loop for the fragmentize transformation. -/
 private partial def fragmentizeLoop
     (todo : List (Option Highlighted))
     (ctxStack : Array HlCtx)
-    (querySpanStack : Array Bool)
     (st : FragState) : Except String FragState := do
   match todo with
   | [] => return st
   | none :: rest =>
     let st := st.closeCtx
-    let querySpanStack := if !querySpanStack.isEmpty then querySpanStack.pop else querySpanStack
-    let st := { st with insideQuerySpan := if querySpanStack.isEmpty then false else querySpanStack.back! }
-    fragmentizeLoop rest ctxStack.pop querySpanStack st
+    fragmentizeLoop rest ctxStack.pop st
   | some (.seq xs) :: rest =>
-    fragmentizeLoop (xs.toList.map some ++ rest) ctxStack querySpanStack st
+    fragmentizeLoop (xs.toList.map some ++ rest) ctxStack st
   | some (.tactics info s e x) :: rest =>
     let st := st.openCtx (.tactics info s e)
-    fragmentizeLoop (some x :: none :: rest) (ctxStack.push (.tactics info s e)) (querySpanStack.push st.insideQuerySpan) st
+    fragmentizeLoop (some x :: none :: rest) (ctxStack.push (.tactics info s e)) st
   | some (.span info x) :: rest =>
     let st := st.openCtx (.span info)
-    let st := { st with insideQuerySpan := false }
-    fragmentizeLoop (some x :: none :: rest) (ctxStack.push (.span info)) (querySpanStack.push false) st
+    fragmentizeLoop (some x :: none :: rest) (ctxStack.push (.span info)) st
   | some (.token tok) :: rest =>
-    let mut qss := querySpanStack
-    let mut s := st
-    if tok.kind matches .keyword .. then
-      if queryCommands.contains tok.content then
-        if !qss.isEmpty then
-          qss := qss.pop.push true
-          s := { s with insideQuerySpan := true }
-          if let some info := findSpanInfo ctxStack then
-            s := { s with pendingCommandOutput := some info }
-    s := s.pushSC (SlideCode.hl (.token tok))
-    fragmentizeLoop rest ctxStack qss s
+    let st := st.pushSC (SlideCode.hl (.token tok))
+    fragmentizeLoop rest ctxStack st
   | some (.point kind info) :: rest =>
-    let st := st.pushSC (SlideCode.hl (.point kind info))
-    fragmentizeLoop rest ctxStack querySpanStack st
+    let st := st.pushSC (.commandOutput #[(kind, info)])
+    fragmentizeLoop rest ctxStack st
   | some (.text s) :: rest =>
     let st ← processTextNode st s true
-    fragmentizeLoop rest ctxStack querySpanStack st
+    fragmentizeLoop rest ctxStack st
   | some (.unparsed s) :: rest =>
     let st ← processTextNode st s false
-    fragmentizeLoop rest ctxStack querySpanStack st
+    fragmentizeLoop rest ctxStack st
 
 /--
 Transforms a {name}`Highlighted` tree into a {name}`SlideCode` tree, processing magic comments.
@@ -735,17 +706,11 @@ public def fragmentize (hl : Highlighted) : Except String SlideCode := do
     pendingFragments := #[]
     activeLineFragment := none
     openInlineFragments := #[]
-    pendingCommandOutput := none
-    insideQuerySpan := false
   }
-  let finalSt ← fragmentizeLoop [some hl] #[] #[] initSt
+  let finalSt ← fragmentizeLoop [some hl] #[] initSt
   if !finalSt.openInlineFragments.isEmpty then
     throw "Unclosed inline fragment (/- !fragment -/ without /- !end fragment -/)"
   if finalSt.hideDepth > 0 then
     throw "Unclosed hide or replace region (/- !hide -/ or /- !replace ... -/ without matching end marker)"
-  -- Emit any pending command output before closing
-  let finalSt := match finalSt.pendingCommandOutput with
-    | some info => { finalSt.pushSC (.commandOutput info) with pendingCommandOutput := none }
-    | none => finalSt
   let finalSt := finalSt.closeActiveLine
   return finalSt.doc.toSlideCode

--- a/browser-tests/conftest.py
+++ b/browser-tests/conftest.py
@@ -122,3 +122,27 @@ def page(browser):
     page = browser.new_page()
     yield page
     page.close()
+
+
+def goto_slide_by_title(page, base_url, title):
+    """Navigate to a slide by its heading text.
+
+    Uses Reveal.js's slide indexing: finds the section whose heading matches
+    *title*, computes its index among top-level sections, and navigates to
+    ``#/<index>``.
+    """
+    page.goto(f"{base_url}/index.html")
+    page.wait_for_load_state("networkidle")
+    index = page.evaluate("""(title) => {
+        const sections = document.querySelectorAll('.slides > section');
+        for (let i = 0; i < sections.length; i++) {
+            const h = sections[i].querySelector('h1, h2, h3');
+            if (h && h.textContent.trim() === title) return i;
+        }
+        return -1;
+    }""", title)
+    assert index >= 0, f"Slide with title '{title}' not found"
+    page.goto(f"{base_url}/index.html#/{index}")
+    page.wait_for_load_state("networkidle")
+    page.wait_for_timeout(1000)
+    return page.locator(".slides > section").nth(index)

--- a/browser-tests/test_comments.py
+++ b/browser-tests/test_comments.py
@@ -1,17 +1,14 @@
 """Browser tests for Lean comment highlighting (verso#274 workaround)."""
 
+from conftest import goto_slide_by_title
 from playwright.sync_api import expect, Page
 
 
 class TestCommentHighlighting:
     def test_line_comment_styled(self, code_url: str, page: Page):
         """Line comments (-- ...) should be wrapped in .lean-comment spans."""
-        # Comments is slide index 7
-        page.goto(f"{code_url}/index.html#/7")
-        page.wait_for_load_state("networkidle")
-        page.wait_for_timeout(1000)
+        slide = goto_slide_by_title(page, code_url, "Comments")
 
-        slide = page.locator(".slides > section").nth(7)
         comments = slide.locator(".lean-comment")
         assert comments.count() >= 1
 
@@ -21,22 +18,16 @@ class TestCommentHighlighting:
 
     def test_block_comment_styled(self, code_url: str, page: Page):
         """Block comments (/- ... -/) should be wrapped in .lean-comment spans."""
-        page.goto(f"{code_url}/index.html#/7")
-        page.wait_for_load_state("networkidle")
-        page.wait_for_timeout(1000)
+        slide = goto_slide_by_title(page, code_url, "Comments")
 
-        slide = page.locator(".slides > section").nth(7)
         comments = slide.locator(".lean-comment")
         texts = [comments.nth(i).inner_text() for i in range(comments.count())]
         assert any("A block comment" in t for t in texts)
 
     def test_comment_has_italic_style(self, code_url: str, page: Page):
         """Comments should be rendered in italic."""
-        page.goto(f"{code_url}/index.html#/7")
-        page.wait_for_load_state("networkidle")
-        page.wait_for_timeout(1000)
+        slide = goto_slide_by_title(page, code_url, "Comments")
 
-        slide = page.locator(".slides > section").nth(7)
         comment = slide.locator(".lean-comment").first
         expect(comment).to_be_visible()
 
@@ -45,11 +36,8 @@ class TestCommentHighlighting:
 
     def test_non_comment_text_unchanged(self, code_url: str, page: Page):
         """Code tokens outside comments should not be wrapped in .lean-comment."""
-        page.goto(f"{code_url}/index.html#/7")
-        page.wait_for_load_state("networkidle")
-        page.wait_for_timeout(1000)
+        slide = goto_slide_by_title(page, code_url, "Comments")
 
-        slide = page.locator(".slides > section").nth(7)
         code_block = slide.locator("code.hl.lean.block")
         text = code_block.inner_text()
 

--- a/browser-tests/test_eval_ordering.py
+++ b/browser-tests/test_eval_ordering.py
@@ -1,0 +1,141 @@
+"""Tests that #eval, #check, #print, and #reduce output appears
+after the command, not at the end of the code block."""
+
+from bs4 import BeautifulSoup
+
+
+def _get_slide_code_children(doc, slide_title):
+    """Find the code block in a slide and return (ordered) list of
+    ('code', text) for code tokens or ('output', text) for command output divs."""
+    sections = doc.select("section")
+    for s in sections:
+        h = s.find(["h1", "h2", "h3"])
+        if h and slide_title in h.get_text():
+            code = s.select_one("code.hl.lean.block")
+            assert code, f"No code block found in slide '{slide_title}'"
+            items = []
+            for child in code.children:
+                if (
+                    hasattr(child, "name")
+                    and child.name == "div"
+                    and "command-output" in (child.get("class") or [])
+                ):
+                    items.append(("output", child.get_text().strip()))
+                elif hasattr(child, "name"):
+                    text = child.get_text().strip()
+                    if text:
+                        items.append(("code", text))
+            return items
+    raise AssertionError(f"Slide '{slide_title}' not found")
+
+
+class TestEvalMultiline:
+    def test_eval_multiline_output_after_expression(self, code_doc: BeautifulSoup):
+        """#eval output should appear after the full expression, even when it spans multiple lines."""
+        items = _get_slide_code_children(code_doc, "Eval Multiline")
+        outputs = [(i, kind, text) for i, (kind, text) in enumerate(items) if kind == "output"]
+        assert len(outputs) == 1, f"Expected 1 output, got {len(outputs)}"
+
+        output_idx, _, output_text = outputs[0]
+        assert "6" in output_text
+
+        # The expression tokens (1, +, 2, 3) should all come before the output
+        expr_indices = [
+            i for i, (k, t) in enumerate(items)
+            if k == "code" and t in ("1", "2", "3", "+")
+        ]
+        assert all(i < output_idx for i in expr_indices), \
+            "Expression tokens should appear before the output"
+
+
+class TestEvalOrdering:
+    def test_eval_outputs_interleaved(self, code_doc: BeautifulSoup):
+        """#eval outputs should appear after each command, not at the end."""
+        items = _get_slide_code_children(code_doc, "Eval Ordering")
+        outputs = [(kind, text) for kind, text in items if kind == "output"]
+        assert len(outputs) == 3
+
+        output_first_idx = next(
+            i for i, (k, t) in enumerate(items) if k == "output" and "first" in t
+        )
+        def_idx = next(
+            i for i, (k, t) in enumerate(items) if k == "code" and t == "evalMiddle"
+        )
+        output_second_idx = next(
+            i for i, (k, t) in enumerate(items) if k == "output" and "4" in t and "first" not in t
+        )
+        output_third_idx = next(
+            i for i, (k, t) in enumerate(items) if k == "output" and "8" in t
+        )
+
+        # First output before the def, second and third after it
+        assert output_first_idx < def_idx, \
+            "First #eval output should appear before 'def evalMiddle'"
+        assert output_second_idx > def_idx, \
+            "Second #eval output should appear after 'def evalMiddle'"
+        # Each output appears exactly once, in order
+        assert output_first_idx < output_second_idx < output_third_idx, \
+            "Outputs should appear in command order"
+
+    def test_check_outputs_interleaved(self, code_doc: BeautifulSoup):
+        """#check outputs should appear after each command, not at the end."""
+        items = _get_slide_code_children(code_doc, "Check Ordering")
+        outputs = [(kind, text) for kind, text in items if kind == "output"]
+        assert len(outputs) == 2
+
+        output1_idx = next(
+            i for i, (k, t) in enumerate(items) if k == "output" and "Nat" in t
+        )
+        def_middle_idx = next(
+            i for i, (k, t) in enumerate(items) if k == "code" and t == "checkMiddle" and i > output1_idx
+        )
+        output2_idx = next(
+            i for i, (k, t) in enumerate(items) if k == "output" and "String" in t
+        )
+
+        assert output1_idx < def_middle_idx, \
+            "First #check output should appear before 'def checkMiddle'"
+        assert output2_idx > def_middle_idx, \
+            "Second #check output should appear after 'def checkMiddle'"
+
+    def test_print_outputs_interleaved(self, code_doc: BeautifulSoup):
+        """#print outputs should appear after each command, not at the end."""
+        items = _get_slide_code_children(code_doc, "Print Ordering")
+        outputs = [(kind, text) for kind, text in items if kind == "output"]
+        assert len(outputs) == 2
+
+        output1_idx = next(
+            i for i, (k, t) in enumerate(items) if k == "output" and "100" in t
+        )
+        def_middle_idx = next(
+            i for i, (k, t) in enumerate(items) if k == "code" and t == "printMiddle" and i > output1_idx
+        )
+        output2_idx = next(
+            i for i, (k, t) in enumerate(items) if k == "output" and "true" in t
+        )
+
+        assert output1_idx < def_middle_idx, \
+            "First #print output should appear before 'def printMiddle'"
+        assert output2_idx > def_middle_idx, \
+            "Second #print output should appear after 'def printMiddle'"
+
+    def test_reduce_outputs_interleaved(self, code_doc: BeautifulSoup):
+        """#reduce outputs should appear after each command, not at the end."""
+        items = _get_slide_code_children(code_doc, "Reduce Ordering")
+        outputs = [(kind, text) for kind, text in items if kind == "output"]
+        assert len(outputs) == 2
+
+        output1_idx = next(
+            i for i, (k, t) in enumerate(items) if k == "output" and t == "5"
+        )
+        def_middle_idx = next(
+            i for i, (k, t) in enumerate(items) if k == "code" and t == "reduceMiddle"
+        )
+        output2_idx = next(
+            i for i, (k, t) in enumerate(items) if k == "output" and t == "20"
+        )
+
+        assert output1_idx < def_middle_idx, \
+            "First #reduce output should appear before 'def reduceMiddle'"
+        assert output2_idx > def_middle_idx, \
+            "Second #reduce output should appear after 'def reduceMiddle'"

--- a/browser-tests/test_other_languages.py
+++ b/browser-tests/test_other_languages.py
@@ -1,15 +1,13 @@
 """Browser tests for non-Lean code blocks (highlight.js integration)."""
 
+from conftest import goto_slide_by_title
 from playwright.sync_api import expect, Page
 
 
 class TestHighlightJs:
     def test_rust_code_block_highlighted(self, code_url: str, page: Page):
         """highlight.js should inject hljs-* spans into the Rust code block."""
-        # Rust Code is slide index 8
-        page.goto(f"{code_url}/index.html#/8")
-        page.wait_for_load_state("networkidle")
-        page.wait_for_timeout(1000)
+        goto_slide_by_title(page, code_url, "Rust Code")
 
         block = page.locator("pre > code.language-rust")
         expect(block).to_be_visible()
@@ -32,9 +30,7 @@ class TestHighlightJs:
 
     def test_rust_block_has_box_styling(self, code_url: str, page: Page):
         """Rust code blocks should have box styling (border-radius, shadow)."""
-        page.goto(f"{code_url}/index.html#/8")
-        page.wait_for_load_state("networkidle")
-        page.wait_for_timeout(1000)
+        goto_slide_by_title(page, code_url, "Rust Code")
 
         pre = page.locator("pre:has(> code.language-rust)")
         expect(pre).to_be_visible()

--- a/browser-tests/test_replace.py
+++ b/browser-tests/test_replace.py
@@ -1,17 +1,14 @@
 """Browser tests for /- !replace ... -/ magic comments."""
 
+from conftest import goto_slide_by_title
 from playwright.sync_api import expect, Page
 
 
 class TestReplace:
     def test_replacement_text_visible(self, code_url: str, page: Page):
         """The replacement text '...' should appear in the rendered code."""
-        # Replace is slide index 6
-        page.goto(f"{code_url}/index.html#/6")
-        page.wait_for_load_state("networkidle")
-        page.wait_for_timeout(1000)
+        slide = goto_slide_by_title(page, code_url, "Replace")
 
-        slide = page.locator(".slides > section").nth(6)
         code_block = slide.locator("code.hl.lean.block")
         expect(code_block).to_be_visible()
 
@@ -20,11 +17,8 @@ class TestReplace:
 
     def test_original_code_hidden(self, code_url: str, page: Page):
         """The original code between replace markers should not appear."""
-        page.goto(f"{code_url}/index.html#/6")
-        page.wait_for_load_state("networkidle")
-        page.wait_for_timeout(1000)
+        slide = goto_slide_by_title(page, code_url, "Replace")
 
-        slide = page.locator(".slides > section").nth(6)
         code_block = slide.locator("code.hl.lean.block")
         text = code_block.inner_text()
 
@@ -34,11 +28,8 @@ class TestReplace:
 
     def test_surrounding_code_present(self, code_url: str, page: Page):
         """Code outside the replace markers should render normally."""
-        page.goto(f"{code_url}/index.html#/6")
-        page.wait_for_load_state("networkidle")
-        page.wait_for_timeout(1000)
+        slide = goto_slide_by_title(page, code_url, "Replace")
 
-        slide = page.locator(".slides > section").nth(6)
         code_block = slide.locator("code.hl.lean.block")
         text = code_block.inner_text()
 

--- a/panel/jsconfig.json
+++ b/panel/jsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "lib": ["ES2024", "DOM", "DOM.Iterable"],
         "target": "ES2024",
-        "noEmit": true
+        "noEmit": true,
+        "strict": true
     },
     "include": ["pretty.js", "panel.js", "lightbox.js", "globals.d.ts"]
 }

--- a/panel/lightbox.js
+++ b/panel/lightbox.js
@@ -167,14 +167,15 @@
 
         // Render docstrings with marked
         if (typeof marked !== "undefined") {
+            var m = /** @type {typeof marked} */ (marked);
             inner.querySelectorAll(".docstring").forEach(function (ds) {
-                ds.innerHTML = marked.parse(ds.textContent || "");
+                ds.innerHTML = /** @type {string} */ (m.parse(ds.textContent || ""));
             });
         }
 
         // Set up binding highlighting within the lightbox
         inner.addEventListener("mouseover", function (e) {
-            var tok = /** @type {Element | null} */ (e.target).closest(".token[data-binding]");
+            var tok = /** @type {Element} */ (e.target).closest(".token[data-binding]");
             if (!tok) return;
             var binding = tok.getAttribute("data-binding");
             if (!binding) return;
@@ -184,7 +185,7 @@
             });
         });
         inner.addEventListener("mouseout", function (e) {
-            var tok = /** @type {Element | null} */ (e.target).closest(".token[data-binding]");
+            var tok = /** @type {Element} */ (e.target).closest(".token[data-binding]");
             if (!tok) return;
             inner.querySelectorAll(".token.binding-hl").forEach(function (t) {
                 t.classList.remove("binding-hl");

--- a/panel/panel.js
+++ b/panel/panel.js
@@ -36,9 +36,9 @@
     /** @param {Element} blockEl */
     function setupBlock(blockEl) {
         var block = /** @type {PanelBlock} */ (blockEl);
-        var codeEl = block.querySelector("code.hl.lean.block");
-        var panel = /** @type {InfoPanel | null} */ (block.querySelector(".info-panel"));
-        if (!codeEl || !panel) return;
+        var codeEl = /** @type {Element} */ (block.querySelector("code.hl.lean.block"));
+        var panel = /** @type {InfoPanel} */ (block.querySelector(".info-panel"));
+        if (!block.querySelector("code.hl.lean.block") || !block.querySelector(".info-panel")) return;
 
         block._activeSource = null;
 
@@ -63,16 +63,16 @@
                 clearHoverPreview(codeEl);
             }
         });
-        codeEl.addEventListener("mouseout", function (/** @type {MouseEvent} */ e) {
+        /** @type {HTMLElement} */ (codeEl).addEventListener("mouseout", function (e) {
             if (!e.relatedTarget || !codeEl.contains(/** @type {Node} */ (e.relatedTarget))) {
                 clearHoverPreview(codeEl);
             }
         });
 
         // Binding highlighting — works across code and panel
-        /** @param {MouseEvent} e */
+        /** @param {Event} e */
         function onBindingOver(e) {
-            var tok = /** @type {Element | null} */ (e.target).closest(".token[data-binding]");
+            var tok = /** @type {Element} */ (e.target).closest(".token[data-binding]");
             if (!tok) return;
             var binding = tok.getAttribute("data-binding");
             if (!binding) return;
@@ -84,9 +84,9 @@
                 t.classList.add("binding-hl");
             });
         }
-        /** @param {MouseEvent} e */
+        /** @param {Event} e */
         function onBindingOut(e) {
-            var tok = /** @type {Element | null} */ (e.target).closest(".token[data-binding]");
+            var tok = /** @type {Element} */ (e.target).closest(".token[data-binding]");
             if (!tok) return;
             codeEl.querySelectorAll(".token.binding-hl").forEach(function (t) {
                 t.classList.remove("binding-hl");
@@ -167,7 +167,7 @@
     function cycleClickable(block, chain) {
         if (chain.length === 0) return null;
         var active = block._activeSource;
-        var idx = chain.indexOf(active);
+        var idx = active ? chain.indexOf(active) : -1;
         if (idx >= 0 && idx < chain.length - 1) {
             return chain[idx + 1];
         }
@@ -253,8 +253,9 @@
 
         // Render docstrings with marked
         if (typeof marked !== "undefined") {
+            var m = /** @type {typeof marked} */ (marked);
             panel.querySelectorAll(".docstring").forEach(function (ds) {
-                ds.innerHTML = marked.parse(ds.textContent || "");
+                ds.innerHTML = /** @type {string} */ (m.parse(ds.textContent || ""));
             });
         }
     }

--- a/panel/panel.js
+++ b/panel/panel.js
@@ -38,7 +38,8 @@
         var block = /** @type {PanelBlock} */ (blockEl);
         var codeEl = /** @type {Element} */ (block.querySelector("code.hl.lean.block"));
         var panel = /** @type {InfoPanel} */ (block.querySelector(".info-panel"));
-        if (!block.querySelector("code.hl.lean.block") || !block.querySelector(".info-panel")) return;
+        if (!block.querySelector("code.hl.lean.block") || !block.querySelector(".info-panel"))
+            return;
 
         block._activeSource = null;
 

--- a/panel/pretty.js
+++ b/panel/pretty.js
@@ -304,7 +304,8 @@ function be(w, groups, ctx, measurer) {
             continue;
         }
         // Pop current item — O(1). g.items retains the rest.
-        var i = g.items.pop();
+        // Length was checked above, so pop always returns a value.
+        var i = /** @type {WorkItem} */ (g.items.pop());
 
         switch (i.f.type) {
             case "nil":


### PR DESCRIPTION
The output from #eval was being emitted at the end of the code block. Now, the parser's source locations are correctly used.