### PR TITLE
feat: show code from imported libraries

### DIFF
--- a/Demo.lean
+++ b/Demo.lean
@@ -262,6 +262,26 @@ def x := "Module A!"
 We can refer to {name}`x`.
 :::
 
+# Library Code
+
+Show the current source of a declaration from a dependency:
+
+```leanLibCode Verso.Code.External (package := verso) (decl := Verso.Code.External.withNl)
+/--
+Adds a newline to a string if it doesn't already end with one.
+-/
+public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
+```
+
+Or a specific line range:
+
+```leanLibCode Verso.Code.External (package := verso) (startLine := 74) (endLine := 77)
+/--
+Adds a newline to a string if it doesn't already end with one.
+-/
+public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
+```
+
 # Fragment Styles
 
 :::fragment fadeUp

--- a/Demo.lean
+++ b/Demo.lean
@@ -275,7 +275,7 @@ public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s
 
 Or a specific line range:
 
-```leanLibCode Verso.Code.External (package := verso) (startLine := 75) (endLine := 77)
+```leanLibCode Verso.Code.External (package := verso) (startLine := 77) (endLine := 77)
 public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
 ```
 

--- a/Demo.lean
+++ b/Demo.lean
@@ -275,10 +275,7 @@ public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s
 
 Or a specific line range:
 
-```leanLibCode Verso.Code.External (package := verso) (startLine := 74) (endLine := 77)
-/--
-Adds a newline to a string if it doesn't already end with one.
--/
+```leanLibCode Verso.Code.External (package := verso) (startLine := 75) (endLine := 77)
 public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
 ```
 

--- a/README.md
+++ b/README.md
@@ -544,20 +544,21 @@ Arguments:
   resolvable with a package qualifier.
 - `decl` — optional declaration name; extracts the item whose
   declarations include this name.
-- `startLine` / `endLine`: optional 1-based inclusive line range;
-  must be provided together and cannot combine with `decl`.
-- `panel`: a flag that determines whether to show the interactive info panel under the slide
-  (default `true`). Disable with `-panel`; re-enable explicitly with `+panel`.
+- `startLine` / `endLine`: optional 1-based inclusive line range; must
+  be provided together and cannot combine with `decl`.
+- `panel`: a flag that determines whether to show the interactive info
+  panel under the slide (default `true`). Disable with `-panel`;
+  re-enable explicitly with `+panel`.
 
 Omitting `decl` and the line range shows the entire module.
 
 #### Wiring up the Lake build
 
-For this to work, the highlighted source code of the library must
-be available for the slides to read. The highlighted code can be
-built using the `highlighted` facet in Lake. To arrange for Lake
-to build this automatically, the slides must declare a `needs`
-dependency so Lake builds the facet before elaborating the slides.
+For this to work, the highlighted source code of the library must be
+available for the slides to read. The highlighted code can be built
+using the `highlighted` facet in Lake. To arrange for Lake to build
+this automatically, the slides must declare a `needs` dependency so
+Lake builds the facet before elaborating the slides.
 
 In `lakefile.toml`:
 
@@ -587,13 +588,14 @@ lean_lib MySlides where
   needs := #[`@mypkg:highlighted]
 ```
 
-With this declaration, `lake build` on the slides project produces
-the highlighted JSON before Lean elaborates `leanLibCode` blocks. If
-the facet isn't available, elaboration fails fast with a reminder to
-add the `needs` entry. It won't silently trigger a large build while
+With this declaration, `lake build` on the slides project produces the
+highlighted JSON before Lean elaborates `leanLibCode` blocks. If the
+facet isn't available, elaboration fails fast with a reminder to add
+the `needs` entry. It won't silently trigger a large build while
 elaborating the slides.
 
-Lean's own prelude and `Std` modules don't need the `needs` configuration.
+Lean's own prelude and `Std` modules don't need the `needs`
+configuration.
 
 ## Document-Level Configuration
 

--- a/README.md
+++ b/README.md
@@ -508,6 +508,85 @@ def f := /- !fragment -/42/- !end fragment -/
 ```
 ````
 
+### Library Code
+
+The `leanLibCode` code block shows the current source of a
+declaration, or a line range, from a library the presentation depends
+on. The block body contains the code from the library, and it is an error if it 
+does not match. If the library changes, the block stops matching and Lean
+offers a quickfix suggestion with the updated source.
+
+````
+```leanLibCode MyLib.Foo (decl := MyLib.Foo.bar)
+def bar : Nat := 42
+```
+````
+
+````
+```leanLibCode MyLib.Foo (startLine := 10) (endLine := 30)
+-- lines 10..30 of MyLib.Foo
+```
+````
+
+Arguments:
+
+- The first positional argument is the module name.
+- `package` — optional. Disambiguates when several packages may
+  contain a module with the same name, or when the module is only
+  resolvable with a package qualifier.
+- `decl` — optional declaration name; extracts the item whose
+  declarations include this name.
+- `startLine` / `endLine`: optional 1-based inclusive line range;
+  must be provided together and cannot combine with `decl`.
+- `panel`: a flag that determines whether to show the interactive info panel under the slide
+  (default `true`).
+
+Omitting `decl` and the line range shows the entire module.
+
+#### Wiring up the Lake build
+
+For this to work, the highlighted source code of the library must
+be available for the slides to read. The highlighted code can be
+built using the `highlighted` facet in Lake. To arrange for Lake
+to build this automatically, the slides must declare a `needs`
+dependency so Lake builds the facet before elaborating the slides.
+
+In `lakefile.toml`:
+
+```toml
+[[lean_lib]]
+name = "MySlides"
+needs = ["@mypkg/+MyLib.Foo:highlighted"]
+```
+
+Or a whole package at once:
+
+```toml
+needs = ["@mypkg:highlighted"]
+```
+
+In `lakefile.lean`:
+
+```lean
+lean_lib MySlides where
+  needs := #[`@mypkg/+MyLib.Foo:highlighted]
+```
+
+Or for an entire package:
+
+```lean
+lean_lib MySlides where
+  needs := #[`@mypkg:highlighted]
+```
+
+With this declaration, `lake build` on the slides project produces
+the highlighted JSON before Lean elaborates `leanLibCode` blocks. If
+the facet isn't available, elaboration fails fast with a reminder to
+add the `needs` entry. It won't silently trigger a large build while
+elaborating the slides.
+
+Lean's own prelude and `Std` modules don't need the `needs` configuration.
+
 ## Document-Level Configuration
 
 Document-level `reveal.js` settings live on the `Config` value passed

--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ Arguments:
 - `startLine` / `endLine`: optional 1-based inclusive line range;
   must be provided together and cannot combine with `decl`.
 - `panel`: a flag that determines whether to show the interactive info panel under the slide
-  (default `true`).
+  (default `true`). Disable with `-panel`; re-enable explicitly with `+panel`.
 
 Omitting `decl` and the line range shows the entire module.
 

--- a/README.md
+++ b/README.md
@@ -512,9 +512,17 @@ def f := /- !fragment -/42/- !end fragment -/
 
 The `leanLibCode` code block shows the current source of a
 declaration, or a line range, from a library the presentation depends
-on. The block body contains the code from the library, and it is an error if it 
-does not match. If the library changes, the block stops matching and Lean
-offers a quickfix suggestion with the updated source.
+on. The block body contains the expected code from the library, and it
+is an error if it does not match.
+
+If the library changes, the block stops matching and Lean offers a
+clickable quickfix that replaces the block with the current source. In
+line-range mode, when the body still appears in the library at a
+different range (because lines were inserted or removed earlier in the
+file), Lean additionally offers a quickfix that updates
+`(startLine := …) (endLine := …)` to where the body is now. Small
+character-level edits within lines (renames, typos) are tolerated when
+locating the new range.
 
 ````
 ```leanLibCode MyLib.Foo (decl := MyLib.Foo.bar)

--- a/TestElab/FindBodyLineRange.lean
+++ b/TestElab/FindBodyLineRange.lean
@@ -5,11 +5,10 @@ Author: David Thrane Christiansen
 -/
 
 /-
-Unit tests for `VersoSlides.findBodyLineRange`. Each test wraps a chunk of fake
-"module source" in a single `ModuleItem` (range/kind/defines are irrelevant —
-the function only reads `item.code.toString`) and asserts that the returned
-1-based source line range matches expectation, or `none` when the body is too
-far from anything in the module.
+Unit tests for `VersoSlides.findBodyLineRange`. Each test wraps a chunk of fake "module source" in a
+single `ModuleItem` (range/kind/defines are irrelevant — the function only reads
+`item.code.toString`) and asserts that the returned 1-based source line range matches expectation,
+or `none` when the body is too far from anything in the module.
 -/
 import SubVerso.Module
 import SubVerso.Highlighting.Highlighted
@@ -19,12 +18,14 @@ open SubVerso.Module
 open SubVerso.Highlighting (Highlighted)
 open VersoSlides
 
-/-- Wrap a string as a single `ModuleItem`. The function under test only looks
-at `item.code.toString`, so the other fields are placeholders. -/
+/--
+Wraps a string as a single `ModuleItem`. The function under test only looks at `item.code.toString`,
+so the other fields are placeholders.
+-/
 private def mkItem (text : String) : ModuleItem :=
   { range := none, kind := `command, defines := #[], code := .text text }
 
-/-- Convenience: search `body` against a single-item array built from `modText`. -/
+/-- Convenience wrapper that searches `body` against a single-item array built from `modText`. -/
 private def find (body modText : String) : Option (Nat × Nat × String) :=
   findBodyLineRange body #[mkItem modText]
 
@@ -101,9 +102,9 @@ private def mod5 : String := "module Foo\n\nimport Bar\n\ndef hello := 42\n"
   find "def hello := 42"
     "def x := 1\ndef hello := 99\ndef hello := 42\n"
 
--- Module has a noise line between two body matches; line-level DP absorbs it
--- via delete-mod (cost = noise line length). The body needs to be long enough
--- relative to the noise line for the `body.length / 2` cutoff to admit it.
+-- Module has a noise line between two body matches; line-level DP absorbs it via delete-mod (cost =
+-- noise line length). The body needs to be long enough relative to the noise line for the
+-- `body.length / 2` cutoff to admit it.
 /--
 info: some (1, 3, "module Foo with a long-enough body to admit one inserted noise line\nx\nimport Bar")
 -/
@@ -118,16 +119,15 @@ info: some (1, 3, "module Foo with a long-enough body to admit one inserted nois
 #guard_msgs in
 #eval find "deff hello := 42" mod5
 
--- Whitespace-only lines in body are filtered before matching. (Use a tight
--- module so the only sensible alignment is the obvious one — `mod5` has an
--- intermediate `import Bar` line that the DP would otherwise prefer to
--- substitute against, since char-distance is cheaper than the line skip.)
+-- Whitespace-only lines in body are filtered before matching. (Use a tight module so the only
+-- sensible alignment is the obvious one — `mod5` has an intermediate `import Bar` line that the DP
+-- would otherwise prefer to substitute against, since char-distance is cheaper than the line skip.)
 /-- info: some (1, 2, "module Foo\ndef hello := 42\n") -/
 #guard_msgs in
 #eval find "module Foo\n\n\ndef hello := 42" "module Foo\ndef hello := 42\n"
 
--- Body longer than the module — body lines that can't be matched force the
--- cutoff to fail, so we report no match instead of a misleading partial.
+-- Body longer than the module — body lines that can't be matched force the cutoff to fail, so we
+-- report no match instead of a misleading partial.
 /-- info: none -/
 #guard_msgs in
 #eval

--- a/TestElab/FindBodyLineRange.lean
+++ b/TestElab/FindBodyLineRange.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+
+/-
+Unit tests for `VersoSlides.findBodyLineRange`. Each test wraps a chunk of fake
+"module source" in a single `ModuleItem` (range/kind/defines are irrelevant —
+the function only reads `item.code.toString`) and asserts that the returned
+1-based source line range matches expectation, or `none` when the body is too
+far from anything in the module.
+-/
+import SubVerso.Module
+import SubVerso.Highlighting.Highlighted
+import VersoSlides.LibModule
+
+open SubVerso.Module
+open SubVerso.Highlighting (Highlighted)
+open VersoSlides
+
+/-- Wrap a string as a single `ModuleItem`. The function under test only looks
+at `item.code.toString`, so the other fields are placeholders. -/
+private def mkItem (text : String) : ModuleItem :=
+  { range := none, kind := `command, defines := #[], code := .text text }
+
+/-- Convenience: search `body` against a single-item array built from `modText`. -/
+private def find (body modText : String) : Option (Nat × Nat × String) :=
+  findBodyLineRange body #[mkItem modText]
+
+private def mod5 : String := "module Foo\n\nimport Bar\n\ndef hello := 42\n"
+
+-- Exact one-line match.
+/-- info: some (5, 5, "def hello := 42\n") -/
+#guard_msgs in
+#eval find "def hello := 42" mod5
+
+-- Exact match at first line.
+/-- info: some (1, 1, "module Foo\n") -/
+#guard_msgs in
+#eval find "module Foo" mod5
+
+-- Exact match in middle.
+/-- info: some (3, 3, "import Bar\n") -/
+#guard_msgs in
+#eval find "import Bar" mod5
+
+-- Multi-line exact match across consecutive non-blank lines (blanks are filtered).
+/-- info: some (1, 5, "module Foo\n\nimport Bar\n\ndef hello := 42\n") -/
+#guard_msgs in
+#eval find "module Foo\nimport Bar\ndef hello := 42" mod5
+
+-- Body has an extra line (`x`) not in the module. Char-level DP absorbs it
+-- as a single-char body skip and still finds the right region.
+/-- info: some (1, 5, "module Foo\n\nimport Bar\n\ndef hello := 42\n") -/
+#guard_msgs in
+#eval find "module Foo\nimport Bar\nx\ndef hello := 42" mod5
+
+
+-- Renamed identifier: char-level edits within a line, well within `body.length / 2`.
+/-- info: some (5, 5, "def hello := 42\n") -/
+#guard_msgs in
+#eval find "def hello := 99" mod5
+
+/-- info: some (5, 5, "def hello := 42\n") -/
+#guard_msgs in
+#eval find "def yellow := 'x'" mod5
+
+/-- info: some (5, 5, "def hello := 42\n") -/
+#guard_msgs in
+#eval find "def cea := 'x'" mod5
+
+/-- info: none -/
+#guard_msgs in
+#eval find "def x := 'x'" mod5
+
+-- Char-level edits across multiple lines, one or two per line.
+/-- info: some (1, 5, "module Foo\n\nimport Bar\n\ndef hello := 42\n") -/
+#guard_msgs in
+#eval find "module Bar\nimport Baz\ndef hello := 42" mod5
+
+-- Body bears no resemblance — distance exceeds cutoff.
+/-- info: none -/
+#guard_msgs in
+#eval find "this body has nothing to do with the module at all" mod5
+
+-- Empty body returns `none`.
+/-- info: none -/
+#guard_msgs in
+#eval find "" mod5
+
+-- Empty module returns `none`.
+/-- info: none -/
+#guard_msgs in
+#eval find "anything" ""
+
+-- Module has two `def` lines; the body matches the second more closely.
+/-- info: some (3, 3, "def hello := 42\n") -/
+#guard_msgs in
+#eval
+  find "def hello := 42"
+    "def x := 1\ndef hello := 99\ndef hello := 42\n"
+
+-- Module has a noise line between two body matches; line-level DP absorbs it
+-- via delete-mod (cost = noise line length). The body needs to be long enough
+-- relative to the noise line for the `body.length / 2` cutoff to admit it.
+/--
+info: some (1, 3, "module Foo with a long-enough body to admit one inserted noise line\nx\nimport Bar")
+-/
+#guard_msgs in
+#eval
+  find
+    "module Foo with a long-enough body to admit one inserted noise line\nimport Bar"
+    "module Foo with a long-enough body to admit one inserted noise line\nx\nimport Bar"
+
+-- Small typo on a keyword (`def` → `deff`).
+/-- info: some (5, 5, "def hello := 42\n") -/
+#guard_msgs in
+#eval find "deff hello := 42" mod5
+
+-- Whitespace-only lines in body are filtered before matching. (Use a tight
+-- module so the only sensible alignment is the obvious one — `mod5` has an
+-- intermediate `import Bar` line that the DP would otherwise prefer to
+-- substitute against, since char-distance is cheaper than the line skip.)
+/-- info: some (1, 2, "module Foo\ndef hello := 42\n") -/
+#guard_msgs in
+#eval find "module Foo\n\n\ndef hello := 42" "module Foo\ndef hello := 42\n"
+
+-- Body longer than the module — body lines that can't be matched force the
+-- cutoff to fail, so we report no match instead of a misleading partial.
+/-- info: none -/
+#guard_msgs in
+#eval
+  find (.ofList (.replicate 50 'x') ++ "\n" ++
+        .ofList (.replicate 50 'y'))
+       "short"

--- a/TestElab/LibCode.lean
+++ b/TestElab/LibCode.lean
@@ -94,10 +94,10 @@ error: Code block does not match the current library code:
 
 
 Hint: Update the line range or replace with the current library code
-  • ```leanLibCode Verso.Code.External (package := verso) (startLine := 5̵1̵7̲7̲) (endLine := 5̵1̵7̲7̲)
+  • Update line numbers:```leanLibCode Verso.Code.External (package := verso) (startLine := 5̵1̵7̲7̲) (endLine := 5̵1̵7̲7̲)
     public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
     ```
-  • ```leanLibCode Verso.Code.External (package := verso) (startLine := 51) (endLine := 51)
+  • Update expected code:```leanLibCode Verso.Code.External (package := verso) (startLine := 51) (endLine := 51)
     public m̵e̵t̵a̵ ̵d̵e̵f̵ ̵w̵i̵t̵h̵N̵l̵ ̵(̵s̵c̲l̲a̲s̲s̲ ̲E̲x̲t̲e̲r̲n̲a̲l̲C̲o̲d̲e̲ ̲(̲g̲e̲n̲r̲e̲ : S̵t̵r̵i̵n̵g̵)̵ ̵:̵ ̵S̵t̵r̵i̵n̵g̵ ̵:̵=̵ ̵i̵f̵ ̵s̵.̵e̵n̵d̵s̵W̵i̵t̵h̵ ̵"̵\̵n̵"̵ ̵t̵h̵e̵n̵ ̵s̵ ̵e̵l̵s̵e̵ ̵s̵ ̵+̵+̵ ̵"̵\̵n̵"̵G̲e̲n̲r̲e̲)̲ ̲w̲h̲e̲r̲e̲
     ```
 -/
@@ -124,10 +124,10 @@ error: Code block does not match the current library code:
 
 
 Hint: Update the line range or replace with the current library code
-  • ```leanLibCode Verso.Code.External (package := verso) (startLine := 9̵9̵7̲7̲) (endLine := 9̵9̵7̲7̲)
+  • Update line numbers:```leanLibCode Verso.Code.External (package := verso) (startLine := 9̵9̵7̲7̲) (endLine := 9̵9̵7̲7̲)
     public meta def withNl (t̵s̲ : String) : String := if t̵s̲.endsWith "\n" then t̵s̲ e̵l̵e̲l̲se̵e̲ t̵ ̵s̲ ̲++ "\n"
     ```
-  • ```leanLibCode Verso.Code.External (package := verso) (startLine := 99) (endLine := 99)
+  • Update expected code:```leanLibCode Verso.Code.External (package := verso) (startLine := 99) (endLine := 99)
     p̵u̵b̵l̵i̵c̵ ̵m̵e̵t̵a̵ ̵d̵e̵f̵ ̵w̵i̵t̵h̵N̵l̵ ̵(̵t̵ ̵:̵ ̵S̵t̵r̵i̵n̵g̵)̵ ̵:̵ ̵S̵t̵r̵i̵n̵g̵ ̵:̵=̵ ̵i̵f̵ ̵t̵.̵e̵n̵d̵s̵W̵i̵t̵h̵ ̵"̵\̵n̵"̵ ̵t̵h̵e̵n̵ ̵t̵ ̵e̵l̵s̵e̵ ̵t̵ ̵+̵+̵ ̵"̵\̵n̵"̵-̲-̲ ̲T̲O̲D̲O̲ ̲t̲e̲s̲t̲ ̲t̲h̲r̲e̲s̲h̲o̲l̲d̲s̲/̲s̲o̲r̲t̲i̲n̲g̲
     ```
 -/

--- a/TestElab/LibCode.lean
+++ b/TestElab/LibCode.lean
@@ -94,10 +94,12 @@ error: Code block does not match the current library code:
 
 
 Hint: Update the line range or replace with the current library code
-  • Update line numbers:```leanLibCode Verso.Code.External (package := verso) (startLine := 5̵1̵7̲7̲) (endLine := 5̵1̵7̲7̲)
+  • Update line numbers:
+    ```leanLibCode Verso.Code.External (package := verso) (startLine := 5̵1̵7̲7̲) (endLine := 5̵1̵7̲7̲)
     public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
     ```
-  • Update expected code:```leanLibCode Verso.Code.External (package := verso) (startLine := 51) (endLine := 51)
+  • Update expected code:
+    ```leanLibCode Verso.Code.External (package := verso) (startLine := 51) (endLine := 51)
     public m̵e̵t̵a̵ ̵d̵e̵f̵ ̵w̵i̵t̵h̵N̵l̵ ̵(̵s̵c̲l̲a̲s̲s̲ ̲E̲x̲t̲e̲r̲n̲a̲l̲C̲o̲d̲e̲ ̲(̲g̲e̲n̲r̲e̲ : S̵t̵r̵i̵n̵g̵)̵ ̵:̵ ̵S̵t̵r̵i̵n̵g̵ ̵:̵=̵ ̵i̵f̵ ̵s̵.̵e̵n̵d̵s̵W̵i̵t̵h̵ ̵"̵\̵n̵"̵ ̵t̵h̵e̵n̵ ̵s̵ ̵e̵l̵s̵e̵ ̵s̵ ̵+̵+̵ ̵"̵\̵n̵"̵G̲e̲n̲r̲e̲)̲ ̲w̲h̲e̲r̲e̲
     ```
 -/
@@ -124,10 +126,12 @@ error: Code block does not match the current library code:
 
 
 Hint: Update the line range or replace with the current library code
-  • Update line numbers:```leanLibCode Verso.Code.External (package := verso) (startLine := 9̵9̵7̲7̲) (endLine := 9̵9̵7̲7̲)
+  • Update line numbers:
+    ```leanLibCode Verso.Code.External (package := verso) (startLine := 9̵9̵7̲7̲) (endLine := 9̵9̵7̲7̲)
     public meta def withNl (t̵s̲ : String) : String := if t̵s̲.endsWith "\n" then t̵s̲ e̵l̵e̲l̲se̵e̲ t̵ ̵s̲ ̲++ "\n"
     ```
-  • Update expected code:```leanLibCode Verso.Code.External (package := verso) (startLine := 99) (endLine := 99)
+  • Update expected code:
+    ```leanLibCode Verso.Code.External (package := verso) (startLine := 99) (endLine := 99)
     p̵u̵b̵l̵i̵c̵ ̵m̵e̵t̵a̵ ̵d̵e̵f̵ ̵w̵i̵t̵h̵N̵l̵ ̵(̵t̵ ̵:̵ ̵S̵t̵r̵i̵n̵g̵)̵ ̵:̵ ̵S̵t̵r̵i̵n̵g̵ ̵:̵=̵ ̵i̵f̵ ̵t̵.̵e̵n̵d̵s̵W̵i̵t̵h̵ ̵"̵\̵n̵"̵ ̵t̵h̵e̵n̵ ̵t̵ ̵e̵l̵s̵e̵ ̵t̵ ̵+̵+̵ ̵"̵\̵n̵"̵-̲-̲ ̲T̲O̲D̲O̲ ̲t̲e̲s̲t̲ ̲t̲h̲r̲e̲s̲h̲o̲l̲d̲s̲/̲s̲o̲r̲t̲i̲n̲g̲
     ```
 -/

--- a/TestElab/LibCode.lean
+++ b/TestElab/LibCode.lean
@@ -42,6 +42,22 @@ public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s
 ```
 :::::::
 
+-- Panel toggle: `(panel := false)` suppresses the interactive info panel.
+-- This pins the only public-facing knob with no other coverage.
+#guard_msgs in
+#docs (Slides) libNoPanel "Lib No Panel" :=
+:::::::
+
+# Lib No Panel
+
+```leanLibCode Verso.Code.External (package := verso) (decl := Verso.Code.External.withNl) -panel
+/--
+Adds a newline to a string if it doesn't already end with one.
+-/
+public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
+```
+:::::::
+
 -- Drift detection: when the body doesn't match the library source, the block
 -- emits a diff and a quickfix suggestion with the current source. The
 -- expected docstring below contains `/--` and `-/` from the diff; Lean's

--- a/TestElab/LibCode.lean
+++ b/TestElab/LibCode.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+/-
+Tests for `leanLibCode`: the code block that shows source from an external
+library module via the `highlighted` Lake facet.
+-/
+import VersoSlides
+import Verso.Doc.Concrete
+
+open VersoSlides
+
+-- Decl mode: the happy path, extracting a declaration by name.
+#guard_msgs in
+#docs (Slides) libDecl "Lib Decl" :=
+:::::::
+
+# Lib Decl
+
+```leanLibCode Verso.Code.External (package := verso) (decl := Verso.Code.External.withNl)
+/--
+Adds a newline to a string if it doesn't already end with one.
+-/
+public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
+```
+:::::::
+
+-- Line range mode: same declaration extracted by line numbers.
+#guard_msgs in
+#docs (Slides) libLines "Lib Lines" :=
+:::::::
+
+# Lib Lines
+
+```leanLibCode Verso.Code.External (package := verso) (startLine := 74) (endLine := 77)
+/--
+Adds a newline to a string if it doesn't already end with one.
+-/
+public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
+```
+:::::::
+
+-- Drift detection: when the body doesn't match the library source, the block
+-- emits a diff and a quickfix suggestion with the current source. The
+-- expected docstring below contains `/--` and `-/` from the diff; Lean's
+-- lexer balances them as nested block comments inside the outer docstring.
+/--
+error: Code block does not match the current library source:
+- public meta def withNl (s : String) : String := if s.endsWith "wrong" then s else s ++ "wrong"
++ /--
++ Adds a newline to a string if it doesn't already end with one.
++ -/
++ public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
+
+
+Hint: Replace with the current library source
+  /̲-̲-̲
+  ̲A̲d̲d̲s̲ ̲a̲ ̲n̲e̲w̲l̲i̲n̲e̲ ̲t̲o̲ ̲a̲ ̲s̲t̲r̲i̲n̲g̲ ̲i̲f̲ ̲i̲t̲ ̲d̲o̲e̲s̲n̲'̲t̲ ̲a̲l̲r̲e̲a̲d̲y̲ ̲e̲n̲d̲ ̲w̲i̲t̲h̲ ̲o̲n̲e̲.̲
+  ̲-̲/̲
+  ̲public meta def withNl (s : String) : String := if s.endsWith "̵w̵r̵o̵n̵g̵"̵"̲\̲n̲"̲ then s else s ++ "̵w̵r̵o̵n̵g̵"̵"̲\̲n̲"̲
+-/
+#guard_msgs in
+#docs (Slides) libDrift "Lib Drift" :=
+:::::::
+
+# Lib Drift
+
+```leanLibCode Verso.Code.External (package := verso) (startLine := 77) (endLine := 77)
+public meta def withNl (s : String) : String := if s.endsWith "wrong" then s else s ++ "wrong"
+```
+:::::::
+
+-- Decl name not found: a near-miss typo gets Levenshtein-bounded suggestions
+-- ranked by edit distance, top 10. Snapshot is sensitive to nearby names in
+-- `Verso.Code.External`; update if upstream Verso renames or adds adjacent
+-- declarations.
+/--
+error: No declaration named `Verso.Code.External.withN` in module. Did you mean: [Verso.Code.External.withNl, Verso.Code.External.lit, Verso.Code.External.anchor]?
+-/
+#guard_msgs in
+#docs (Slides) libNoDeclTypo "Lib No Decl Typo" :=
+:::::::
+
+# Lib No Decl Typo
+
+```leanLibCode Verso.Code.External (package := verso) (decl := Verso.Code.External.withN)
+-- typo for `withNl`
+```
+:::::::
+
+-- Decl name with no near matches: error reports no suggestions.
+/--
+error: No declaration named `Verso.Code.External.totallyUnrelatedNameXYZ` in module.
+-/
+#guard_msgs in
+#docs (Slides) libNoDeclFar "Lib No Decl Far" :=
+:::::::
+
+# Lib No Decl Far
+
+```leanLibCode Verso.Code.External (package := verso) (decl := Verso.Code.External.totallyUnrelatedNameXYZ)
+-- nothing close
+```
+:::::::
+
+-- `decl` and `startLine`/`endLine` are mutually exclusive.
+/--
+error: Cannot combine `decl` with `startLine`/`endLine`.
+-/
+#guard_msgs in
+#docs (Slides) libConflict "Lib Conflict" :=
+:::::::
+
+# Lib Conflict
+
+```leanLibCode Verso.Code.External (package := verso) (decl := Verso.Code.External.withNl) (startLine := 74) (endLine := 77)
+-- ignored
+```
+:::::::
+
+-- Fallback path: `Init.Util` isn't a Lake module, so `leanLibCode` falls back
+-- to invoking `subverso-extract-mod` directly. This exercises the fallback
+-- branch, which sets `LEAN_SRC_PATH` to the toolchain's `src/lean`. Targets a
+-- small stable declaration (`dbgTraceVal`); the body is captured from the live
+-- source, so if Lean rewrites it, update the snapshot.
+#guard_msgs in
+#docs (Slides) libFallback "Lib Fallback" :=
+:::::::
+
+# Lib Fallback
+
+```leanLibCode Init.Util (decl := dbgTraceVal)
+def dbgTraceVal {α : Type u} [ToString α] (a : α) : α :=
+  dbgTrace (toString a) (fun _ => a)
+```
+:::::::
+
+-- Line range with no overlapping items: error mentions the module's line count.
+/--
+error: No items in module overlap lines 99000..99100 (module has 854 lines).
+-/
+#guard_msgs in
+#docs (Slides) libNoOverlap "Lib No Overlap" :=
+:::::::
+
+# Lib No Overlap
+
+```leanLibCode Verso.Code.External (package := verso) (startLine := 99000) (endLine := 99100)
+-- out of range
+```
+:::::::
+
+

--- a/TestElab/LibCode.lean
+++ b/TestElab/LibCode.lean
@@ -73,10 +73,10 @@ Hint: Replace with the current library code
   ```
 -/
 #guard_msgs in
-#docs (Slides) libDrift "Lib Drift" :=
+#docs (Slides) keepUp "Keeping up with changes" :=
 :::::::
 
-# Lib Drift
+# Keeping Up
 
 ```leanLibCode Verso.Code.External (package := verso) (startLine := 77) (endLine := 77)
 public meta def withNl (s : String) : String := if s.endsWith "wrong" then s else s ++ "wrong"
@@ -84,7 +84,7 @@ public meta def withNl (s : String) : String := if s.endsWith "wrong" then s els
 :::::::
 
 -- Stale line numbers: body matches the library, but at a different line range
--- than the user wrote. Drift fires, and the hint offers TWO clickable fixes:
+-- than the user wrote. The hint offers TWO clickable fixes:
 -- update the line range to where the body actually appears (51 → 77), or
 -- replace the body with whatever line 51 currently contains.
 /--

--- a/TestElab/LibCode.lean
+++ b/TestElab/LibCode.lean
@@ -58,24 +58,19 @@ public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s
 ```
 :::::::
 
--- Drift detection: when the body doesn't match the library source, the block
--- emits a diff and a quickfix suggestion with the current source. The
--- expected docstring below contains `/--` and `-/` from the diff; Lean's
--- lexer balances them as nested block comments inside the outer docstring.
+-- When the body doesn't match the library code, the block emits a diff and a clickable quickfix
+-- that replaces the entire `leanLibCode` block (directive line + body) with the current library
+-- code. With line range `77..77` the slicer extracts only the def line, so the body diff is clean.
 /--
-error: Code block does not match the current library source:
+error: Code block does not match the current library code:
 - public meta def withNl (s : String) : String := if s.endsWith "wrong" then s else s ++ "wrong"
-+ /--
-+ Adds a newline to a string if it doesn't already end with one.
-+ -/
 + public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
 
 
-Hint: Replace with the current library source
-  /̲-̲-̲
-  ̲A̲d̲d̲s̲ ̲a̲ ̲n̲e̲w̲l̲i̲n̲e̲ ̲t̲o̲ ̲a̲ ̲s̲t̲r̲i̲n̲g̲ ̲i̲f̲ ̲i̲t̲ ̲d̲o̲e̲s̲n̲'̲t̲ ̲a̲l̲r̲e̲a̲d̲y̲ ̲e̲n̲d̲ ̲w̲i̲t̲h̲ ̲o̲n̲e̲.̲
-  ̲-̲/̲
-  ̲public meta def withNl (s : String) : String := if s.endsWith "̵w̵r̵o̵n̵g̵"̵"̲\̲n̲"̲ then s else s ++ "̵w̵r̵o̵n̵g̵"̵"̲\̲n̲"̲
+Hint: Replace with the current library code
+  ```leanLibCode Verso.Code.External (package := verso) (startLine := 77) (endLine := 77)
+  public meta def withNl (s : String) : String := if s.endsWith "w̵r̵o̵\̲ng̵" then s else s ++ "w̵r̵o̵\̲ng̵"
+  ```
 -/
 #guard_msgs in
 #docs (Slides) libDrift "Lib Drift" :=
@@ -85,6 +80,65 @@ Hint: Replace with the current library source
 
 ```leanLibCode Verso.Code.External (package := verso) (startLine := 77) (endLine := 77)
 public meta def withNl (s : String) : String := if s.endsWith "wrong" then s else s ++ "wrong"
+```
+:::::::
+
+-- Stale line numbers: body matches the library, but at a different line range
+-- than the user wrote. Drift fires, and the hint offers TWO clickable fixes:
+-- update the line range to where the body actually appears (51 → 77), or
+-- replace the body with whatever line 51 currently contains.
+/--
+error: Code block does not match the current library code:
+- public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
++ public class ExternalCode (genre : Genre) where
+
+
+Hint: Update the line range or replace with the current library code
+  • ```leanLibCode Verso.Code.External (package := verso) (startLine := 5̵1̵7̲7̲) (endLine := 5̵1̵7̲7̲)
+    public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
+    ```
+  • ```leanLibCode Verso.Code.External (package := verso) (startLine := 51) (endLine := 51)
+    public m̵e̵t̵a̵ ̵d̵e̵f̵ ̵w̵i̵t̵h̵N̵l̵ ̵(̵s̵c̲l̲a̲s̲s̲ ̲E̲x̲t̲e̲r̲n̲a̲l̲C̲o̲d̲e̲ ̲(̲g̲e̲n̲r̲e̲ : S̵t̵r̵i̵n̵g̵)̵ ̵:̵ ̵S̵t̵r̵i̵n̵g̵ ̵:̵=̵ ̵i̵f̵ ̵s̵.̵e̵n̵d̵s̵W̵i̵t̵h̵ ̵"̵\̵n̵"̵ ̵t̵h̵e̵n̵ ̵s̵ ̵e̵l̵s̵e̵ ̵s̵ ̵+̵+̵ ̵"̵\̵n̵"̵G̲e̲n̲r̲e̲)̲ ̲w̲h̲e̲r̲e̲
+    ```
+-/
+#guard_msgs in
+#docs (Slides) libStaleLines "Lib Stale Lines" :=
+:::::::
+
+# Lib Stale Lines
+
+```leanLibCode Verso.Code.External (package := verso) (startLine := 51) (endLine := 51)
+public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
+```
+:::::::
+
+-- Renamed variable: body differs from the library by character-level edits
+-- (here `s` → `t` throughout) AND the user wrote stale line numbers. The
+-- fuzzy fallback in `findBodyLineRange` still finds the right line via
+-- Levenshtein-bounded approximate substring match. The hint offers a
+-- clickable line-range fix and a body replace.
+/--
+error: Code block does not match the current library code:
+- public meta def withNl (t : String) : String := if t.endsWith "\n" then t else t ++ "\n"
++ -- TODO test thresholds/sorting
+
+
+Hint: Update the line range or replace with the current library code
+  • ```leanLibCode Verso.Code.External (package := verso) (startLine := 9̵9̵7̲7̲) (endLine := 9̵9̵7̲7̲)
+    public meta def withNl (t̵s̲ : String) : String := if t̵s̲.endsWith "\n" then t̵s̲ e̵l̵e̲l̲se̵e̲ t̵ ̵s̲ ̲++ "\n"
+    ```
+  • ```leanLibCode Verso.Code.External (package := verso) (startLine := 99) (endLine := 99)
+    p̵u̵b̵l̵i̵c̵ ̵m̵e̵t̵a̵ ̵d̵e̵f̵ ̵w̵i̵t̵h̵N̵l̵ ̵(̵t̵ ̵:̵ ̵S̵t̵r̵i̵n̵g̵)̵ ̵:̵ ̵S̵t̵r̵i̵n̵g̵ ̵:̵=̵ ̵i̵f̵ ̵t̵.̵e̵n̵d̵s̵W̵i̵t̵h̵ ̵"̵\̵n̵"̵ ̵t̵h̵e̵n̵ ̵t̵ ̵e̵l̵s̵e̵ ̵t̵ ̵+̵+̵ ̵"̵\̵n̵"̵-̲-̲ ̲T̲O̲D̲O̲ ̲t̲e̲s̲t̲ ̲t̲h̲r̲e̲s̲h̲o̲l̲d̲s̲/̲s̲o̲r̲t̲i̲n̲g̲
+    ```
+-/
+#guard_msgs in
+#docs (Slides) libRename "Lib Rename" :=
+:::::::
+
+# Lib Rename
+
+```leanLibCode Verso.Code.External (package := verso) (startLine := 99) (endLine := 99)
+public meta def withNl (t : String) : String := if t.endsWith "\n" then t else t ++ "\n"
 ```
 :::::::
 
@@ -167,5 +221,3 @@ error: No items in module overlap lines 99000..99100 (module has 854 lines).
 -- out of range
 ```
 :::::::
-
-

--- a/VersoSlides.lean
+++ b/VersoSlides.lean
@@ -18,3 +18,4 @@ import VersoSlides.SlideCode
 import VersoSlides.SlideCode.Export
 import VersoSlides.SlideCode.Render
 import VersoSlides.ModuleExample
+import VersoSlides.LibModule

--- a/VersoSlides/LibModule.lean
+++ b/VersoSlides/LibModule.lean
@@ -160,7 +160,7 @@ private def loadLibModule [Monad m] [MonadEnv m] [MonadError m] [MonadLiftT IO m
       return entry.items
     else
       throwErrorAt blame
-        m!"The highlighted JSON for `{modName}` changed mid-session (cached hash `{entry.fileHash}`, new hash `{currentHash}`). Please restart the Lean server for this file."
+        m!"The highlighted JSON for `{modName}` changed mid-session. Please restart the current file to re-read the library."
   let text := String.fromUTF8! bytes
   let json ← IO.ofExcept (Json.parse text)
   let mod ←

--- a/VersoSlides/LibModule.lean
+++ b/VersoSlides/LibModule.lean
@@ -69,19 +69,23 @@ private structure LoadedLibModule where
   fileHash : UInt64
   items : Array ModuleItem
 
-/-- Environment extension holding parsed external-library modules for the current Lean session.
-Keyed by module name; invalidated across sessions when the env resets, and
-invalidated within a session by a file-hash check in `loadLibModule`. -/
+/--
+Environment extension holding parsed external-library modules for the current Lean session. Keyed by
+module name; invalidated across sessions when the env resets, and invalidated within a session by a
+file-hash check in `loadLibModule`.
+-/
 private initialize loadedLibModulesExt :
     EnvExtension (Std.HashMap Name LoadedLibModule) ←
   registerEnvExtension (pure {})
 
-/-- Query Lake for the bytes of the `highlighted` facet for `modName`.
-Uses `--no-build`: if the facet hasn't been built, this fails fast instead of
-silently triggering a full dep build from inside elaboration.
+/--
+Queries Lake for the bytes of the `highlighted` facet for `modName`. Uses `--no-build`: if the facet
+hasn't been built, this fails fast instead of silently triggering a full dep build from inside
+elaboration.
 
-If `package?` is given, targets the module within that package (`@pkg/+mod:highlighted`);
-otherwise queries across the workspace (`+mod:highlighted`). -/
+If `package?` is given, targets the module within that package (`@pkg/+mod:highlighted`); otherwise
+queries across the workspace (`+mod:highlighted`).
+-/
 private def queryFacetBytes (modName : Name) (package? : Option Name) :
     IO (Option ByteArray) := do
   let tgt :=
@@ -97,14 +101,15 @@ private def queryFacetBytes (modName : Name) (package? : Option Name) :
   if path.isEmpty then return none
   some <$> IO.FS.readBinFile (System.FilePath.mk path)
 
-/-- Fallback for modules that aren't Lake modules (prelude, stdlib): invoke
-`subverso-extract-mod` directly on a temp-file output. Used only when
-`queryFacetBytes` fails. The temp file is auto-deleted by `withTempFile`.
+/--
+Fallback for modules that aren't Lake modules (prelude, stdlib): invoke `subverso-extract-mod`
+directly on a temp-file output. Used only when `queryFacetBytes` fails. The temp file is
+auto-deleted by `withTempFile`.
 
-`subverso-extract-mod`'s default source-search path is computed from its own
-binary location, which doesn't include the toolchain's `src/lean` directory.
-We override `LEAN_SRC_PATH` with the toolchain sysroot (via `Lean.findSysroot`)
-so prelude and stdlib modules are reachable. -/
+`subverso-extract-mod`'s default source-search path is computed from its own binary location, which
+doesn't include the toolchain's `src/lean` directory. We override `LEAN_SRC_PATH` with the toolchain
+sysroot (via `Lean.findSysroot`) so prelude and stdlib modules are reachable.
+-/
 private def fallbackExtractBytes (modName : Name) : IO (Option ByteArray) := do
   let exeOut ← IO.Process.output {
     cmd := "lake",
@@ -142,9 +147,11 @@ private def noModuleError (modName : Name) (package? : Option Name) : MessageDat
     s!"      needs := #[`{qual}]"
   m!"Couldn't locate highlighted JSON for module `{modName}`.\n\n{tomlHint}\n\n{leanHint}"
 
-/-- Load the parsed `ModuleItem`s for `modName`, hitting the env-extension cache when possible.
-If the cache has a stale entry (file hash changed mid-session), asks the user to restart
-rather than silently handing out a mix of old and new data. -/
+/--
+Loads the parsed `ModuleItem`s for `modName`, hitting the env-extension cache when possible. If the
+cache has a stale entry (file hash changed mid-session), asks the user to restart rather than
+silently handing out a mix of old and new data.
+-/
 private def loadLibModule [Monad m] [MonadEnv m] [MonadError m] [MonadLiftT IO m]
     (modName : Name) (package? : Option Name) (blame : Syntax) : m (Array ModuleItem) := do
   let bytes ←
@@ -171,9 +178,166 @@ private def loadLibModule [Monad m] [MonadEnv m] [MonadError m] [MonadLiftT IO m
     m.insert modName { fileHash := currentHash, items := mod.items }
   return mod.items
 
-/-- Pick the `ModuleItem`s to include based on the user's config (decl, line range, or all). -/
-private def selectItems (items : Array ModuleItem) (cfg : LibModuleConfig)
-    : Except String (Array ModuleItem) := do
+private inductive Ctx where
+  | tactics (goals : Array (Highlighted.Goal Highlighted)) (s e : Nat)
+  | span (info : Array (Highlighted.Span.Kind × Highlighted.MessageContents Highlighted))
+
+/--
+Gets the indicated line range, on the assumption that the code in question starts at line `line`.
+-/
+def getLines (line : Nat) (startLine endLine : Nat) (hl : Highlighted) : Highlighted := Id.run do
+  let mut line := line
+  let mut ctx : List (Highlighted × Ctx × List Highlighted) := []
+  let mut doc : List Highlighted := [hl]
+  let mut out : Highlighted := .empty
+  repeat
+    if line > endLine then break
+    match doc with
+    | [] =>
+      match ctx with
+      | [] => break
+      | (o', .tactics goals s e, next) :: ctx' =>
+        out := o' ++ .tactics goals s e out
+        doc := next
+        ctx := ctx'
+      | (o', .span info, next) :: ctx' =>
+        out := o' ++ .span info out
+        doc := next
+        ctx := ctx'
+    | .text s :: next =>
+      for l in s.splitInclusive '\n' do
+        if line ≥ startLine then out := out ++ .text l.copy
+        if l.endsWith '\n' then line := line + 1
+        if line > endLine then break
+      doc := next
+    | .unparsed s :: next =>
+      for l in s.splitInclusive '\n' do
+        if line ≥ startLine then out := out ++ .unparsed l.copy
+        if l.endsWith '\n' then line := line + 1
+        if line > endLine then break
+      doc := next
+    | .seq xs :: next =>
+      doc := xs.toList ++ next
+    | .token tok :: next =>
+      let mut keep := ""
+      for l in tok.content.splitInclusive '\n' do
+        if line ≥ startLine then keep := keep ++ l.copy
+        if l.endsWith '\n' then line := line + 1
+        if line > endLine then break
+      unless keep.isEmpty do
+        out := out ++ .token { tok with content := keep }
+      doc := next
+    | .tactics goals s e hl :: next =>
+      ctx := (out, .tactics goals s e, next) :: ctx
+      out := .empty
+      doc := [hl]
+    | .span info hl :: next =>
+      ctx := (out, .span info, next) :: ctx
+      out := .empty
+      doc := [hl]
+    | .point kind info :: next =>
+      if line ≥ startLine then
+        out := out ++ .point kind info
+      doc := next
+  return ctx.foldl (init := out) fun
+    | o, (o', .tactics goals s e, _) => o' ++ .tactics goals s e o
+    | o, (o', .span info, _) => o' ++ .span info o
+
+/--
+Extracts the content of a `ModuleItem` clipped to source lines `[sl, el]`,
+or `none` if the item lies entirely outside the range. Items entirely inside
+the range pass through without traversal; only items straddling a boundary
+are walked.
+-/
+private def sliceItem (sl el : Nat) (item : ModuleItem) : Option Highlighted := do
+  let (s, e) ← item.range
+  if e.line < sl ∨ s.line > el then none
+  else if sl ≤ s.line ∧ e.line ≤ el then some item.code
+  else
+    -- Straddles a boundary. The item's `code` begins with whitespace from
+    -- the gap before `s.line`, so trim leading blanks before slicing so the
+    -- line counter starts at `s.line` of the first real character.
+    some (getLines s.line sl el (dropBlanks item.code))
+
+/--
+Searches the source of `items` for the closest substring to `body`, anchored at line boundaries.
+Returns the matched source line range and the matched text, or `none` when no candidate is close
+enough — concretely, when the Levenshtein distance exceeds
+`max(body.length, matchedText.length) / 2`. An exact match returns its location with distance 0.
+
+The returned text contains complete source lines, snapped at both ends and suitable for use directly
+as the body of a quickfix replacement.
+-/
+def findBodyLineRange (body : String) (items : Array ModuleItem) :
+    Option (Nat × Nat × String) := Id.run do
+  if body.isEmpty then return none
+  let modText : String := items.foldl (init := "") fun s i => s ++ i.code.toString
+  if modText.isEmpty then return none
+  let fm := FileMap.ofString modText
+  let bArr := body.toList.toArray
+  let bLen := bArr.size
+  let infty : Nat := body.length + modText.length + 1
+  let mut prev : Vector (Nat × String.Pos.Raw) (bLen + 1) := .replicate _ (0, 0)
+  for h : j in 0...(bLen + 1) do
+    prev := prev.set j (j, 0)
+  let mut curr : Vector (Nat × String.Pos.Raw) (bLen + 1) := .replicate _ (0, 0)
+  let mut bestDist : Nat := infty
+  let mut bestStart : String.Pos.Raw := 0
+  let mut bestEnd : String.Pos.Raw := 0
+  -- Initial `prev[0] = (0, 0)` covers the line-1 free start at byte 0.
+  -- Within the loop, we set `curr[0] = (0, nextPos)` only when `m == '\n'`, so
+  -- `DP[i+1][0]` (which has notional `start = i+1 = nextPos`) is only available
+  -- as a free-start cell when `nextPos` is a line boundary.
+  let mut iPos : String.Pos.Raw := 0
+  while h : !iPos.atEnd modText do
+    let m := iPos.get' modText (by grind)
+    let nextPos := iPos.next' modText (by grind)
+    if m == '\n' then
+      curr := curr.set 0 (0, nextPos)
+    else
+      curr := curr.set 0 (infty, 0)
+    for h : j in 0...bLen do
+      let b := bArr[j]
+      let cost := if m == b then 0 else 1
+      let (dSub, sSub) := prev[j]
+      let (dDel, sDel) := prev[j + 1]
+      let (dIns, sIns) := curr[j]
+      let sub := (dSub + cost, sSub)
+      let del := (dDel + 1, sDel)
+      let ins := (dIns + 1, sIns)
+      let pick :=
+        if sub.1 ≤ del.1 ∧ sub.1 ≤ ins.1 then sub
+        else if del.1 ≤ ins.1 then del else ins
+      curr := curr.set (j + 1) pick
+    let (d, s) := curr[bLen]
+    if d < bestDist then
+      bestDist := d
+      bestStart := s
+      bestEnd := nextPos
+    let tmp := prev
+    prev := curr
+    curr := tmp
+    iPos := nextPos
+  -- Cutoff scales with the larger of body and candidate length so that noise-line
+  -- insertions in the library (which inflate candidate length) don't exclude an
+  -- otherwise-good match. Lengths are in bytes; close enough to chars for ASCII.
+  let candidateLen := bestEnd.byteIdx - bestStart.byteIdx
+  let cutoff := max body.length candidateLen / 2
+  if bestDist > cutoff then return none
+  let endLast := bestEnd.prev modText
+  let startLine := (fm.toPosition bestStart).line
+  let endLine := (fm.toPosition endLast).line
+  let found :=
+    modText.splitInclusive '\n' |>.drop (startLine - 1) |>.take (endLine - startLine + 1)
+      |>.joinString
+  return some (startLine, endLine, found)
+
+/--
+Picks the highlighted code to include based on the user's config (decl, line range, or all). For
+line ranges, slices each overlapping item to the requested lines via `takeLines`.
+-/
+private def selectCode (items : Array ModuleItem) (cfg : LibModuleConfig)
+    : Except String Highlighted := do
   match cfg.decl, cfg.startLine, cfg.endLine with
   | some _, some _, _ | some _, _, some _ =>
     throw "Cannot combine `decl` with `startLine`/`endLine`."
@@ -181,7 +345,7 @@ private def selectItems (items : Array ModuleItem) (cfg : LibModuleConfig)
     throw "Both `startLine` and `endLine` must be provided together."
   | some declName, none, none =>
     match items.find? (·.defines.contains declName.getId) with
-    | some item => return #[item]
+    | some item => return item.code
     | none =>
       let input := declName.getId.toString
       let candidates := items.flatMap (·.defines) |>.map toString
@@ -201,16 +365,51 @@ private def selectItems (items : Array ModuleItem) (cfg : LibModuleConfig)
                 Did you mean: {suggestions.toList}?"
   | none, some sl, some el =>
     if sl > el then throw s!"startLine ({sl}) is greater than endLine ({el})."
-    let overlapping := items.filter fun item =>
-      match item.range with
-      | some (s, e) => s.line ≤ el && sl ≤ e.line
-      | none => false
-    if overlapping.isEmpty then
+    let combined := items.filterMap (sliceItem sl el)
+      |>.foldl (init := Highlighted.empty) (· ++ ·)
+    if combined.isEmpty then
       let total := items.filterMap (·.range.map (·.2.line)) |>.foldl max 0
       throw s!"No items in module overlap lines {sl}..{el} (module has {total} lines)."
-    return overlapping
+    return combined
   | none, none, none =>
-    return items
+    return items.foldl (init := Highlighted.empty) fun acc item => acc ++ item.code
+
+private meta def editCodeBlock [Monad m] [MonadFileMap m] (stx : Syntax) (newArgs? : Option String) (newContents : String) : m (Option String) := do
+  let txt ← getFileMap
+  let some rng := stx.getRange?
+    | pure none
+  let { start := {line := l1, ..}, .. } := txt.utf8RangeToLspRange rng
+  let line1 := (txt.lineStart (l1 + 1)).extract txt.source (txt.lineStart (l1 + 2))
+  let line1ws := line1.takeWhile (· == ' ') |>.copy
+  let line1rest := line1.drop line1ws.length
+  let newContents := line1ws ++ (withNl newContents).replace "\n" ("\n" ++ line1ws)
+  if line1rest.startsWith "```" then
+    match newArgs? with
+    | none =>
+      return some s!"{delims}{line1rest.dropWhile (· == '`') |>.trimAscii}\n{withNl newContents}{delims}"
+    | some newArgs =>
+      let name := line1rest.dropWhile (· == '`') |>.trimAscii |>.takeWhile (!·.isWhitespace) |>.copy
+      let newArgs := newArgs.trimAscii
+      let newArgs := if newArgs.isEmpty then "" else " " ++ newArgs.copy
+      return some s!"{delims}{name}{newArgs}\n{withNl newContents}{delims}"
+  else
+    return none
+where
+  delims : String := Id.run do
+    let mut n := 3
+    let mut run := none
+    let mut iter := newContents.startPos
+    while h : iter ≠ newContents.endPos do
+      let c := iter.get h
+      iter := iter.next h
+      if c == '`' then
+        run := some (run.getD 0 + 1)
+      else if let some k := run then
+        if k > n then n := k
+        run := none
+    if let some k := run then
+      if k > n then n := k
+    n.fold (fun _ _ s => s.push '`') ""
 
 /--
 A code block that shows syntax-highlighted source from an external library module.
@@ -239,20 +438,45 @@ def leanLibCode : CodeBlockExpanderOf LibModuleConfig
     let modName := cfg.«module».getId
     let pkgName? := cfg.«package».map (·.getId)
     let items ← loadLibModule modName pkgName? cfg.«module».raw
-    let selected ←
-      match selectItems items cfg with
+    let hl ←
+      match selectCode items cfg with
       | .ok v => pure v
       | .error msg => throwErrorAt str.raw msg
-    let hl := selected.foldl (init := Highlighted.empty) fun acc item => acc ++ item.code
     let hl := dropBlanks hl
     let hlString := hl.toString
     let replacement := withNl hlString
     let useLine (l : String) : Bool := !l.trimAscii.isEmpty
     if let some diff ← Verso.ExpectString.expectStringOrDiff str replacement (useLine := useLine) then
-      let h : MessageData ←
-        MessageData.hint "Replace with the current library source"
-          #[{ suggestion := .string replacement }] (ref? := some str)
-      logErrorAt str m!"Code block does not match the current library source:\n{diff}{h}"
+      let ref ← getRef
+      let lineHint? : Option String ←
+        match cfg.startLine, cfg.endLine with
+        | some sl, some el =>
+          match findBodyLineRange str.getString items with
+          | some (newSl, newEl, newContents) =>
+            if newSl != sl || newEl != el then
+              let newArgs := [
+                some s!"{cfg.module.getId}",
+                cfg.package.map (s!"(package := {·.getId})"),
+                some s!"(startLine := {newSl})",
+                some s!"(endLine := {newEl})",
+                if !cfg.panel then some "-panel" else none
+              ]
+              editCodeBlock ref (some (" ".intercalate (newArgs.filterMap id))) newContents
+            else pure none
+          | none => pure none
+        | _, _ => pure none
+      if let some edit ← editCodeBlock ref none replacement then
+        let h ←
+          if let some lineHint := lineHint? then
+            m!"Update the line range or replace with the current library code".hint (ref? := some ref) #[
+              { suggestion := lineHint, preInfo? := some "Update line numbers:" },
+              { suggestion := edit, preInfo? := some "Update expected code:" }
+            ]
+          else
+            m!"Replace with the current library code".hint (ref? := some ref) #[edit]
+        logError m!"Code block does not match the current library code:\n{diff}{h}"
+      else
+        logError m!"Code block does not match the current library code:\n{diff}"
     match fragmentize hl.trim with
     | .ok sc =>
       let exported := scToExport sc
@@ -261,5 +485,3 @@ def leanLibCode : CodeBlockExpanderOf LibModuleConfig
            #[Verso.Doc.Block.code $(quote str.getString)])
     | .error msg =>
       throwErrorAt str.raw msg
-
-end VersoSlides

--- a/VersoSlides/LibModule.lean
+++ b/VersoSlides/LibModule.lean
@@ -487,8 +487,8 @@ def leanLibCode : CodeBlockExpanderOf LibModuleConfig
         let h ←
           if let some lineHint := lineHint? then
             m!"Update the line range or replace with the current library code".hint (ref? := some ref) #[
-              { suggestion := lineHint, preInfo? := some "Update line numbers:" },
-              { suggestion := edit, preInfo? := some "Update expected code:" }
+              { suggestion := lineHint, preInfo? := some "Update line numbers:\n" },
+              { suggestion := edit, preInfo? := some "Update expected code:\n" }
             ]
           else
             m!"Replace with the current library code".hint (ref? := some ref) #[edit]

--- a/VersoSlides/LibModule.lean
+++ b/VersoSlides/LibModule.lean
@@ -1,0 +1,265 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+
+import Lean.Elab.Term
+
+import Verso.Code.Highlighted
+import Verso.Code.External
+import Verso.Doc.Elab
+import Verso.Doc.ArgParse
+import Verso.Doc.Helpers
+import Verso.ExpectString
+import Verso.Log
+import SubVerso.Highlighting.Code
+import SubVerso.Module
+
+import VersoSlides.Basic
+import VersoSlides.InlineLean
+import VersoSlides.ModuleExample
+import VersoSlides.SlideCode
+import VersoSlides.SlideCode.Export
+
+open Verso.Doc.Elab
+open Verso.ArgParse
+open Verso.Log
+open Verso.Code.External (withNl)
+open Lean
+open SubVerso.Highlighting
+open SubVerso.Module
+
+namespace VersoSlides
+
+/-- Arguments accepted by `leanLibCode`. -/
+structure LibModuleConfig where
+  /-- The external library module to pull code from. -/
+  «module» : Ident
+  /-- Lake package name. Use this to disambiguate when multiple packages contain a module
+  with the same name, or when the module is not reachable without a package qualifier. -/
+  «package» : Option Ident := none
+  /-- A declaration name — extracts the `ModuleItem` whose `defines` contains this name. -/
+  decl : Option Ident := none
+  /-- 1-based inclusive start line for a line-range extraction. -/
+  startLine : Option Nat := none
+  /-- 1-based inclusive end line for a line-range extraction. -/
+  endLine : Option Nat := none
+  /-- Whether to show the interactive info panel below the slide. -/
+  panel : Bool := true
+
+section
+
+variable [Monad m] [MonadError m]
+
+instance : FromArgs LibModuleConfig m where
+  fromArgs :=
+    LibModuleConfig.mk
+      <$> .positional `module .ident
+      <*> .named `package .ident true
+      <*> .named `decl .ident true
+      <*> .named `startLine .nat true
+      <*> .named `endLine .nat true
+      <*> .flag `panel true
+end
+
+/-- Cached extracted module JSON, keyed by fully-qualified module name. -/
+private structure LoadedLibModule where
+  /-- Hash of the JSON file's bytes at load time. -/
+  fileHash : UInt64
+  items : Array ModuleItem
+
+/-- Environment extension holding parsed external-library modules for the current Lean session.
+Keyed by module name; invalidated across sessions when the env resets, and
+invalidated within a session by a file-hash check in `loadLibModule`. -/
+private initialize loadedLibModulesExt :
+    EnvExtension (Std.HashMap Name LoadedLibModule) ←
+  registerEnvExtension (pure {})
+
+/-- Query Lake for the bytes of the `highlighted` facet for `modName`.
+Uses `--no-build`: if the facet hasn't been built, this fails fast instead of
+silently triggering a full dep build from inside elaboration.
+
+If `package?` is given, targets the module within that package (`@pkg/+mod:highlighted`);
+otherwise queries across the workspace (`+mod:highlighted`). -/
+private def queryFacetBytes (modName : Name) (package? : Option Name) :
+    IO (Option ByteArray) := do
+  let tgt :=
+    match package? with
+    | some p => s!"@{p}/+{modName}:highlighted"
+    | none => s!"+{modName}:highlighted"
+  let out ← IO.Process.output {
+    cmd := "lake",
+    args := #["query", "--no-build", "--text", tgt]
+  }
+  if out.exitCode != 0 then return none
+  let path := out.stdout.trimAscii.copy
+  if path.isEmpty then return none
+  some <$> IO.FS.readBinFile (System.FilePath.mk path)
+
+/-- Fallback for modules that aren't Lake modules (prelude, stdlib): invoke
+`subverso-extract-mod` directly on a temp-file output. Used only when
+`queryFacetBytes` fails. The temp file is auto-deleted by `withTempFile`.
+
+`subverso-extract-mod`'s default source-search path is computed from its own
+binary location, which doesn't include the toolchain's `src/lean` directory.
+We override `LEAN_SRC_PATH` with the toolchain sysroot (via `Lean.findSysroot`)
+so prelude and stdlib modules are reachable. -/
+private def fallbackExtractBytes (modName : Name) : IO (Option ByteArray) := do
+  let exeOut ← IO.Process.output {
+    cmd := "lake",
+    args := #["query", "--text", "subverso-extract-mod"]
+  }
+  if exeOut.exitCode != 0 then return none
+  let exePath := exeOut.stdout.trimAscii.copy
+  if exePath.isEmpty then return none
+  let sysroot ← Lean.findSysroot
+  let srcPath : System.SearchPath :=
+    [sysroot / "src" / "lean" / "lake", sysroot / "src" / "lean"]
+  IO.FS.withTempFile fun _h jsonFile => do
+    let runOut ← IO.Process.output {
+      cmd := exePath,
+      args := #[modName.toString, jsonFile.toString],
+      env := #[("LEAN_SRC_PATH", some srcPath.toString)]
+    }
+    if runOut.exitCode != 0 then return none
+    some <$> IO.FS.readBinFile jsonFile
+
+/-- Diagnostic-friendly guidance when neither the facet nor the fallback can find the module. -/
+private def noModuleError (modName : Name) (package? : Option Name) : MessageData :=
+  let qual :=
+    match package? with
+    | some p => s!"@{p}/+{modName}:highlighted"
+    | none => s!"+{modName}:highlighted"
+  let tomlHint :=
+    "In lakefile.toml, add the library's highlighted facet to your slides lib's needs:\n\n" ++
+    "    [[lean_lib]]\n" ++
+    "    name = \"YourSlidesLib\"\n" ++
+    s!"    needs = [\"{qual}\"]"
+  let leanHint :=
+    "In lakefile.lean:\n\n" ++
+    "    lean_lib YourSlidesLib where\n" ++
+    s!"      needs := #[`{qual}]"
+  m!"Couldn't locate highlighted JSON for module `{modName}`.\n\n{tomlHint}\n\n{leanHint}"
+
+/-- Load the parsed `ModuleItem`s for `modName`, hitting the env-extension cache when possible.
+If the cache has a stale entry (file hash changed mid-session), asks the user to restart
+rather than silently handing out a mix of old and new data. -/
+private def loadLibModule [Monad m] [MonadEnv m] [MonadError m] [MonadLiftT IO m]
+    (modName : Name) (package? : Option Name) (blame : Syntax) : m (Array ModuleItem) := do
+  let bytes ←
+    match ← (queryFacetBytes modName package? : IO _) with
+    | some b => pure b
+    | none =>
+      match ← (fallbackExtractBytes modName : IO _) with
+      | some b => pure b
+      | none => throwErrorAt blame (noModuleError modName package?)
+  let currentHash := hash bytes
+  if let some entry := (loadedLibModulesExt.getState (← getEnv))[modName]? then
+    if entry.fileHash == currentHash then
+      return entry.items
+    else
+      throwErrorAt blame
+        m!"The highlighted JSON for `{modName}` changed mid-session (cached hash `{entry.fileHash}`, new hash `{currentHash}`). Please restart the Lean server for this file."
+  let text := String.fromUTF8! bytes
+  let json ← IO.ofExcept (Json.parse text)
+  let mod ←
+    match Module.fromJson? json with
+    | .ok m => pure m
+    | .error e => throwErrorAt blame m!"Failed to parse highlighted JSON for `{modName}`: {e}"
+  modifyEnv fun env => loadedLibModulesExt.modifyState env fun m =>
+    m.insert modName { fileHash := currentHash, items := mod.items }
+  return mod.items
+
+/-- Pick the `ModuleItem`s to include based on the user's config (decl, line range, or all). -/
+private def selectItems (items : Array ModuleItem) (cfg : LibModuleConfig)
+    : Except String (Array ModuleItem) := do
+  match cfg.decl, cfg.startLine, cfg.endLine with
+  | some _, some _, _ | some _, _, some _ =>
+    throw "Cannot combine `decl` with `startLine`/`endLine`."
+  | none, some _, none | none, none, some _ =>
+    throw "Both `startLine` and `endLine` must be provided together."
+  | some declName, none, none =>
+    match items.find? (·.defines.contains declName.getId) with
+    | some item => return #[item]
+    | none =>
+      let input := declName.getId.toString
+      let candidates := items.flatMap (·.defines) |>.map toString
+      let threshold (name : String) : Nat :=
+        if input.length < 5 then 1
+        else if input.length < 10 then 2
+        else 3 |>.max (max input.length name.length / 5)
+      let scored := candidates.filterMap fun c =>
+        Lean.EditDistance.levenshtein c input (threshold c) |>.map (c, ·)
+      let sorted := scored.qsort fun x y =>
+        x.2 < y.2 || (x.2 == y.2 && x.1 < y.1)
+      let suggestions := sorted.take 10 |>.map (·.1)
+      if suggestions.isEmpty then
+        throw s!"No declaration named `{input}` in module."
+      else
+        throw s!"No declaration named `{input}` in module. \
+                Did you mean: {suggestions.toList}?"
+  | none, some sl, some el =>
+    if sl > el then throw s!"startLine ({sl}) is greater than endLine ({el})."
+    let overlapping := items.filter fun item =>
+      match item.range with
+      | some (s, e) => s.line ≤ el && sl ≤ e.line
+      | none => false
+    if overlapping.isEmpty then
+      let total := items.filterMap (·.range.map (·.2.line)) |>.foldl max 0
+      throw s!"No items in module overlap lines {sl}..{el} (module has {total} lines)."
+    return overlapping
+  | none, none, none =>
+    return items
+
+/--
+A code block that shows syntax-highlighted source from an external library module.
+
+Requires a Lake `needs` entry so the library's `highlighted` facet is built before the
+slides library. The block body is the expected text of the extracted code — if it drifts
+from the library, a quickfix suggestion offers the current source.
+
+Examples:
+
+```
+```leanLibCode MyLib.Foo (decl := MyLib.Foo.bar)
+def bar : Nat := 42
+```
+```
+
+```
+```leanLibCode MyLib.Foo (startLine := 10) (endLine := 30)
+-- lines 10..30 verbatim
+```
+```
+-/
+@[code_block]
+def leanLibCode : CodeBlockExpanderOf LibModuleConfig
+  | cfg, str => do
+    let modName := cfg.«module».getId
+    let pkgName? := cfg.«package».map (·.getId)
+    let items ← loadLibModule modName pkgName? cfg.«module».raw
+    let selected ←
+      match selectItems items cfg with
+      | .ok v => pure v
+      | .error msg => throwErrorAt str.raw msg
+    let hl := selected.foldl (init := Highlighted.empty) fun acc item => acc ++ item.code
+    let hl := dropBlanks hl
+    let hlString := hl.toString
+    let replacement := withNl hlString
+    let useLine (l : String) : Bool := !l.trimAscii.isEmpty
+    if let some diff ← Verso.ExpectString.expectStringOrDiff str replacement (useLine := useLine) then
+      let h : MessageData ←
+        MessageData.hint "Replace with the current library source"
+          #[{ suggestion := .string replacement }] (ref? := some str)
+      logErrorAt str m!"Code block does not match the current library source:\n{diff}{h}"
+    match fragmentize hl.trim with
+    | .ok sc =>
+      let exported := scToExport sc
+      ``(Verso.Doc.Block.other
+           (VersoSlides.BlockExt.slideCode $(quote exported) $(quote cfg.panel))
+           #[Verso.Doc.Block.code $(quote str.getString)])
+    | .error msg =>
+      throwErrorAt str.raw msg
+
+end VersoSlides

--- a/VersoSlides/LibModule.lean
+++ b/VersoSlides/LibModule.lean
@@ -36,8 +36,10 @@ namespace VersoSlides
 structure LibModuleConfig where
   /-- The external library module to pull code from. -/
   «module» : Ident
-  /-- Lake package name. Use this to disambiguate when multiple packages contain a module
-  with the same name, or when the module is not reachable without a package qualifier. -/
+  /--
+  Package name. Disambiguates when multiple packages contain a module with the same name, or
+  when the module is not reachable without a package qualifier.
+  -/
   «package» : Option Ident := none
   /-- A declaration name — extracts the `ModuleItem` whose `defines` contains this name. -/
   decl : Option Ident := none
@@ -102,13 +104,13 @@ private def queryFacetBytes (modName : Name) (package? : Option Name) :
   some <$> IO.FS.readBinFile (System.FilePath.mk path)
 
 /--
-Fallback for modules that aren't Lake modules (prelude, stdlib): invoke `subverso-extract-mod`
-directly on a temp-file output. Used only when `queryFacetBytes` fails. The temp file is
+Fallback for modules that aren't Lake modules (prelude, stdlib): invokes `subverso-extract-mod`
+directly on a temp-file output. Runs only when `queryFacetBytes` fails. The temp file is
 auto-deleted by `withTempFile`.
 
 `subverso-extract-mod`'s default source-search path is computed from its own binary location, which
-doesn't include the toolchain's `src/lean` directory. We override `LEAN_SRC_PATH` with the toolchain
-sysroot (via `Lean.findSysroot`) so prelude and stdlib modules are reachable.
+doesn't include the toolchain's `src/lean` directory. `LEAN_SRC_PATH` is overridden with the
+toolchain sysroot (via `Lean.findSysroot`) so prelude and stdlib modules are reachable.
 -/
 private def fallbackExtractBytes (modName : Name) : IO (Option ByteArray) := do
   let exeOut ← IO.Process.output {
@@ -427,9 +429,12 @@ where
 /--
 A code block that shows syntax-highlighted source from an external library module.
 
-Requires a Lake `needs` entry so the library's `highlighted` facet is built before the
-slides library. The block body is the expected text of the extracted code — if it drifts
-from the library, a quickfix suggestion offers the current source.
+Requires a Lake `needs` entry so the library's `highlighted` facet is built before the slides
+library. The block body is the expected text of the extracted code; if it differs from the library,
+a quickfix suggestion offers the current source.
+
+The code must have already been pre-processed for inclusion. Please refer to the README for
+`verso-slides` for instructions.
 
 Examples:
 

--- a/VersoSlides/LibModule.lean
+++ b/VersoSlides/LibModule.lean
@@ -277,9 +277,7 @@ def findBodyLineRange (body : String) (items : Array ModuleItem) :
   let bArr := body.toList.toArray
   let bLen := bArr.size
   let infty : Nat := body.length + modText.length + 1
-  let mut prev : Vector (Nat × String.Pos.Raw) (bLen + 1) := .replicate _ (0, 0)
-  for h : j in 0...(bLen + 1) do
-    prev := prev.set j (j, 0)
+  let mut prev : Vector (Nat × String.Pos.Raw) (bLen + 1) := .ofFn fun j => (j.val, 0)
   let mut curr : Vector (Nat × String.Pos.Raw) (bLen + 1) := .replicate _ (0, 0)
   let mut bestDist : Nat := infty
   let mut bestStart : String.Pos.Raw := 0
@@ -334,7 +332,7 @@ def findBodyLineRange (body : String) (items : Array ModuleItem) :
 
 /--
 Picks the highlighted code to include based on the user's config (decl, line range, or all). For
-line ranges, slices each overlapping item to the requested lines via `takeLines`.
+line ranges, slices each overlapping item to the requested lines via `sliceItem`.
 -/
 private def selectCode (items : Array ModuleItem) (cfg : LibModuleConfig)
     : Except String Highlighted := do
@@ -352,7 +350,7 @@ private def selectCode (items : Array ModuleItem) (cfg : LibModuleConfig)
       let threshold (name : String) : Nat :=
         if input.length < 5 then 1
         else if input.length < 10 then 2
-        else 3 |>.max (max input.length name.length / 5)
+        else max 3 (max input.length name.length / 5)
       let scored := candidates.filterMap fun c =>
         Lean.EditDistance.levenshtein c input (threshold c) |>.map (c, ·)
       let sorted := scored.qsort fun x y =>
@@ -374,6 +372,21 @@ private def selectCode (items : Array ModuleItem) (cfg : LibModuleConfig)
   | none, none, none =>
     return items.foldl (init := Highlighted.empty) fun acc item => acc ++ item.code
 
+/--
+Builds a quickfix replacement string for the code block at `stx`. Returns the entire
+code block as a single string, with leading whitespace from the opening line preserved as
+indentation on every line of the new body.
+
+If `newArgs?` is `some args`, the directive's arguments are replaced with `args` (the directive
+name is kept); if `none`, the original argument list is left intact and only the body is rewritten
+to `newContents`.
+
+The opening and closing delimiters are sized to be longer than any run of backticks in
+`newContents`, so a body containing nested code blocks still produces a valid block.
+
+Returns `none` when the syntax has no source range, or when the opening line at that range does
+not start with a backtick.
+-/
 private meta def editCodeBlock [Monad m] [MonadFileMap m] (stx : Syntax) (newArgs? : Option String) (newContents : String) : m (Option String) := do
   let txt ← getFileMap
   let some rng := stx.getRange?
@@ -405,10 +418,10 @@ where
       if c == '`' then
         run := some (run.getD 0 + 1)
       else if let some k := run then
-        if k > n then n := k
+        if k ≥ n then n := k + 1
         run := none
     if let some k := run then
-      if k > n then n := k
+      if k ≥ n then n := k + 1
     n.fold (fun _ _ s => s.push '`') ""
 
 /--

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -23,9 +23,10 @@ input_dir webLibAssets where
   path := "web-lib"
 
 lean_lib VersoSlides where
-  needs := #[webLibAssets]
+  needs := #[webLibAssets, `@subverso/«subverso-extract-mod»]
 
-lean_lib Demo
+lean_lib Demo where
+  needs := #[`@verso/+Verso.Code.External:highlighted]
 
 @[default_target] lean_exe «demo-slides» where root := `Main
 
@@ -39,7 +40,8 @@ lean_lib TestFixtures
 lean_exe «test-fixtures-build» where
   root := `TestFixtures.Build
 
-lean_lib TestElab
+lean_lib TestElab where
+  needs := #[`@verso/+Verso.Code.External:highlighted]
 
 lean_lib Tests
 


### PR DESCRIPTION
Adds a `leanLibCode` code block that shows code from an imported library dependency. The code to be shown can be identified either by line ranges or declaration names.

The code block contains the actual code to be shown; this ensures that changes in the library are noticed when rebuilding slides.