### PR TITLE
fix: detect slide background color for Lean lightbox

### DIFF
--- a/TestFixtures/Code.lean
+++ b/TestFixtures/Code.lean
@@ -46,13 +46,6 @@ theorem and_comm_ex (p q : Prop) (h : p ∧ q) : q ∧ p := by
 The function {lean}`hello` was defined above.
 Also try {lean}`Nat.add`.
 
-# Light Inline Lean
-%%%
-backgroundColor := some "#f5f5f5"
-%%%
-
-{lean}`hello` opens its lightbox on a light slide.
-
 # Fragment Effects
 
 ```lean
@@ -164,3 +157,10 @@ fn main() {
     }
 }
 ```
+
+# Light Inline Lean
+%%%
+backgroundColor := some "#f5f5f5"
+%%%
+
+{lean}`hello` on a light slide.

--- a/TestFixtures/Code.lean
+++ b/TestFixtures/Code.lean
@@ -46,6 +46,13 @@ theorem and_comm_ex (p q : Prop) (h : p ∧ q) : q ∧ p := by
 The function {lean}`hello` was defined above.
 Also try {lean}`Nat.add`.
 
+# Light Inline Lean
+%%%
+backgroundColor := some "#f5f5f5"
+%%%
+
+{lean}`hello` opens its lightbox on a light slide.
+
 # Fragment Effects
 
 ```lean

--- a/browser-tests/test_lightbox.py
+++ b/browser-tests/test_lightbox.py
@@ -1,7 +1,7 @@
 """Browser tests for the inline Lean term lightbox overlay."""
 
 from playwright.sync_api import expect, Page
-from conftest import wait_for_reveal_ready
+from conftest import goto_slide_by_title, wait_for_reveal_ready
 
 
 class TestLightboxOpen:
@@ -135,14 +135,16 @@ class TestLightboxThemeColors:
     """The lightbox must follow the slide theme rather than r-overlay's hardcoded dark."""
 
     def _click_first_token(self, page: Page):
-        token = page.locator("code.hl.lean.inline [data-verso-hover]").first
+        """Click within the active slide — multiple slides have inline tokens,
+        and clicking an off-screen one would fail with 'outside the viewport'."""
+        active = page.locator("section.present")
+        token = active.locator("code.hl.lean.inline [data-verso-hover]").first
         token.click()
         page.wait_for_timeout(500)
 
     def test_dark_slide_no_light_bg_class(self, code_url: str, page: Page):
         """Dark slide (default in this fixture): overlay must NOT get slide-light-bg."""
-        page.goto(f"{code_url}/index.html#/3")
-        wait_for_reveal_ready(page)
+        goto_slide_by_title(page, code_url, "Inline Lean")
         self._click_first_token(page)
 
         overlay = page.locator(".r-overlay-lean-hover")
@@ -156,8 +158,7 @@ class TestLightboxThemeColors:
         a dark grey (#191919) rather than pure black. The bug being fixed was
         r-overlay forcing #000 regardless of theme.
         """
-        page.goto(f"{code_url}/index.html#/3")
-        wait_for_reveal_ready(page)
+        goto_slide_by_title(page, code_url, "Inline Lean")
         self._click_first_token(page)
 
         overlay = page.locator(".r-overlay-lean-hover")
@@ -168,12 +169,11 @@ class TestLightboxThemeColors:
     def test_light_slide_copies_light_bg_class(self, code_url: str, page: Page):
         """Light slide: overlay must inherit slide-light-bg from the active section.
 
-        Slide /4 ("Light Inline Lean") has backgroundColor "#f5f5f5", which
+        The "Light Inline Lean" slide has backgroundColor "#f5f5f5", which
         code-block-bg.js tags with .slide-light-bg. lightbox.js copies that
         onto the overlay so the light Lean token palette applies.
         """
-        page.goto(f"{code_url}/index.html#/4")
-        wait_for_reveal_ready(page)
+        goto_slide_by_title(page, code_url, "Light Inline Lean")
 
         # Sanity check: the active section actually got tagged as light.
         active_section = page.locator("section.present").first
@@ -189,8 +189,7 @@ class TestLightboxThemeColors:
 
     def test_light_slide_token_palette_applied(self, code_url: str, page: Page):
         """With slide-light-bg on the overlay, --verso-code-keyword-color uses the light palette."""
-        page.goto(f"{code_url}/index.html#/4")
-        wait_for_reveal_ready(page)
+        goto_slide_by_title(page, code_url, "Light Inline Lean")
         self._click_first_token(page)
 
         overlay = page.locator(".r-overlay-lean-hover")

--- a/browser-tests/test_lightbox.py
+++ b/browser-tests/test_lightbox.py
@@ -131,6 +131,78 @@ class TestLightboxSizing:
         assert overflow == "auto", f"Expected overflow-y: auto, got: {overflow}"
 
 
+class TestLightboxThemeColors:
+    """The lightbox must follow the slide theme rather than r-overlay's hardcoded dark."""
+
+    def _click_first_token(self, page: Page):
+        token = page.locator("code.hl.lean.inline [data-verso-hover]").first
+        token.click()
+        page.wait_for_timeout(500)
+
+    def test_dark_slide_no_light_bg_class(self, code_url: str, page: Page):
+        """Dark slide (default in this fixture): overlay must NOT get slide-light-bg."""
+        page.goto(f"{code_url}/index.html#/3")
+        wait_for_reveal_ready(page)
+        self._click_first_token(page)
+
+        overlay = page.locator(".r-overlay-lean-hover")
+        expect(overlay).to_be_visible()
+        assert "slide-light-bg" not in (overlay.get_attribute("class") or "")
+
+    def test_dark_slide_background_not_black(self, code_url: str, page: Page):
+        """Overlay background should follow the theme, not r-overlay's hardcoded #000.
+
+        The `code` fixture uses `theme := "black"`, whose --r-background-color is
+        a dark grey (#191919) rather than pure black. The bug being fixed was
+        r-overlay forcing #000 regardless of theme.
+        """
+        page.goto(f"{code_url}/index.html#/3")
+        wait_for_reveal_ready(page)
+        self._click_first_token(page)
+
+        overlay = page.locator(".r-overlay-lean-hover")
+        bg = overlay.evaluate("el => getComputedStyle(el).backgroundColor")
+        # rgb(0, 0, 0) would mean r-overlay's dark default is still leaking through.
+        assert bg != "rgb(0, 0, 0)", f"Expected theme bg, got hardcoded black: {bg}"
+
+    def test_light_slide_copies_light_bg_class(self, code_url: str, page: Page):
+        """Light slide: overlay must inherit slide-light-bg from the active section.
+
+        Slide /4 ("Light Inline Lean") has backgroundColor "#f5f5f5", which
+        code-block-bg.js tags with .slide-light-bg. lightbox.js copies that
+        onto the overlay so the light Lean token palette applies.
+        """
+        page.goto(f"{code_url}/index.html#/4")
+        wait_for_reveal_ready(page)
+
+        # Sanity check: the active section actually got tagged as light.
+        active_section = page.locator("section.present").first
+        active_classes = active_section.get_attribute("class") or ""
+        assert "slide-light-bg" in active_classes, (
+            f"Expected slide-light-bg on the active section; got class={active_classes!r}"
+        )
+
+        self._click_first_token(page)
+        overlay = page.locator(".r-overlay-lean-hover")
+        expect(overlay).to_be_visible()
+        assert "slide-light-bg" in (overlay.get_attribute("class") or "")
+
+    def test_light_slide_token_palette_applied(self, code_url: str, page: Page):
+        """With slide-light-bg on the overlay, --verso-code-keyword-color uses the light palette."""
+        page.goto(f"{code_url}/index.html#/4")
+        wait_for_reveal_ready(page)
+        self._click_first_token(page)
+
+        overlay = page.locator(".r-overlay-lean-hover")
+        keyword_color = overlay.evaluate(
+            "el => getComputedStyle(el).getPropertyValue('--verso-code-keyword-color').trim()"
+        )
+        # Light-mode value from slides-highlight.css (`#8839a0`). Dark default is `#c678dd`.
+        assert keyword_color == "#8839a0", (
+            f"Expected light-mode keyword color #8839a0, got {keyword_color!r}"
+        )
+
+
 class TestTippySuppression:
     def test_no_tippy_on_inline_code(self, code_url: str, page: Page):
         """Hovering an inline Lean token should not create a Tippy tooltip."""

--- a/web-lib/panel/lightbox.css
+++ b/web-lib/panel/lightbox.css
@@ -28,6 +28,16 @@ code.hl.lean.inline [data-verso-hover] {
     border-radius: 6px;
     overflow-y: auto;
     overflow-x: hidden;
+    /* `.r-overlay` is reveal.js' image lightbox class and forces a black
+       background. We follow the active reveal theme instead. */
+    background: var(--r-background-color);
+    color: var(--r-main-color);
+}
+
+/* Don't let r-overlay's dark default leak through the content wrapper either. */
+.r-overlay-lean-hover .r-overlay-content {
+    background: transparent;
+    color: inherit;
 }
 
 /* Viewport: content-sized, no absolute positioning or padding gap */

--- a/web-lib/panel/lightbox.js
+++ b/web-lib/panel/lightbox.js
@@ -138,6 +138,13 @@
         var overlay = document.createElement("div");
         overlay.className = "r-overlay r-overlay-lean-hover";
 
+        // Propagate the active slide's light/dark tag to the overlay so the
+        // light-mode Lean token palette in slides-highlight.css applies here.
+        var currentSlide = Reveal.getCurrentSlide();
+        if (currentSlide && currentSlide.classList.contains("slide-light-bg")) {
+            overlay.classList.add("slide-light-bg");
+        }
+
         var viewport = document.createElement("div");
         viewport.className = "r-overlay-viewport";
 

--- a/web-lib/panel/slides-highlight.css
+++ b/web-lib/panel/slides-highlight.css
@@ -65,8 +65,11 @@
     --verso-code-var-color: #56d4c0;
     --verso-code-comment-color: #9da0a8;
 }
-/* Light slides — set per-section by code-block-bg.js */
-.reveal section.slide-light-bg {
+/* Light slides — set per-section by code-block-bg.js. The lean-hover overlay
+   gets the same class copied onto it by lightbox.js so token colors stay
+   readable on light themes. */
+.reveal section.slide-light-bg,
+.reveal .r-overlay-lean-hover.slide-light-bg {
     --verso-code-keyword-color: #8839a0;
     --verso-code-const-color: #1a5fb4;
     --verso-code-var-color: #1a7a6a;


### PR DESCRIPTION
Before, the Lean lightbox used instead of hovers would mix light and dark theme elements when used in light themes, making it hard to read.