### PR TITLE
feat: stretch code boxes

### DIFF
--- a/Demo.lean
+++ b/Demo.lean
@@ -50,10 +50,34 @@ def hello : IO Unit := do
   IO.println "Hello from VersoSlides!"
 ```
 
-```lean
+```lean -stretch
 #check hello
 ```
 And some inline {lean}`hello` for good measure. {lean}`Unit`
+
+# Stretched Code Fills the Slide
+
+```lean
+def answer : Nat := 42
+```
+
+# Text Above Stretched Code
+
+A short paragraph of explanation sits above the code box. The box
+stretches to fill whatever vertical space is left below this text.
+
+```lean
+def double (n : Nat) : Nat := n + n
+```
+
+# Unstretched Code Sizes to Content
+
+Passing `-stretch` opts out of filling, so the box is only as tall as
+the code it contains:
+
+```lean -stretch
+def triple (n : Nat) : Nat := n + n + n
+```
 
 # Code on Light Background
 %%%
@@ -230,12 +254,12 @@ lean_lib MiniRadix
 # Multi-Module Examples
 
 :::leanModules (moduleRoot := Lib)
-```leanModule (moduleName := Lib.A)
+```leanModule (moduleName := Lib.A) -stretch
 module
 public def x : Nat := 1
 def y : Nat := 2
 ```
-```leanModule (moduleName := Lib.B)
+```leanModule (moduleName := Lib.B) -stretch
 module
 import Lib.A
 def z := x
@@ -248,7 +272,7 @@ def x' := y
 # Multi-Module Examples with Lakefiles
 
 :::leanModules
-```leanModule +lakefile
+```leanModule +lakefile -stretch
 import Lake
 open Lake DSL
 
@@ -256,7 +280,7 @@ package p
 
 lean_lib A
 ```
-```leanModule (moduleName := A)
+```leanModule (moduleName := A) -stretch
 def x := "Module A!"
 ```
 We can refer to {name}`x`.
@@ -275,7 +299,7 @@ public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s
 
 Or a specific line range:
 
-```leanLibCode Verso.Code.External (package := verso) (startLine := 77) (endLine := 77)
+```leanLibCode Verso.Code.External (package := verso) (startLine := 77) (endLine := 77) -stretch
 public meta def withNl (s : String) : String := if s.endsWith "\n" then s else s ++ "\n"
 ```
 

--- a/README.md
+++ b/README.md
@@ -400,6 +400,29 @@ Instead of hovers, information about code is revealed on click. This
 is to allow the presenter to point using the mouse without hover boxes
 popping up over content.
 
+### Code Box Sizing
+
+By default, a code box fills the remaining vertical space on its slide.
+This uses `reveal.js`'s `r-stretch` mechanism. Code shorter than the
+available space sits at the top of the box; code taller than the
+available space scrolls within the box. Pass the `-stretch` flag to opt
+out, sizing the box to its content instead:
+
+````
+```lean -stretch
+def answer : Nat := 42
+```
+````
+
+`reveal.js` can only stretch one element per slide. If a slide has more
+than one code box, add `-stretch` to all but one of them; otherwise the
+heights are computed incorrectly. (The standalone `:::stretch` directive,
+documented above, applies the same mechanism to arbitrary content such
+as images.)
+
+The `stretch` flag is available on `lean`, `leanModule`, and
+`leanLibCode` code blocks.
+
 ### Tips
 
 Use the `-show` flag to include Lean code that is not rendered. This
@@ -549,6 +572,10 @@ Arguments:
 - `panel`: a flag that determines whether to show the interactive info
   panel under the slide (default `true`). Disable with `-panel`;
   re-enable explicitly with `+panel`.
+- `stretch`: a flag that determines whether the code box fills the
+  remaining vertical space on the slide (default `true`). Disable with
+  `-stretch` to size the box to its content. See [Code Box
+  Sizing](#code-box-sizing).
 
 Omitting `decl` and the line range shows the entire module.
 

--- a/README.md
+++ b/README.md
@@ -402,11 +402,11 @@ popping up over content.
 
 ### Code Box Sizing
 
-By default, a code box fills the remaining vertical space on its slide.
-This uses `reveal.js`'s `r-stretch` mechanism. Code shorter than the
-available space sits at the top of the box; code taller than the
-available space scrolls within the box. Pass the `-stretch` flag to opt
-out, sizing the box to its content instead:
+By default, a code box fills the remaining vertical space on its
+slide. This uses `reveal.js`'s `r-stretch` mechanism. Code shorter
+than the available space sits at the top of the box; code taller than
+the available space scrolls within the box. Pass the `-stretch` flag
+to opt out, sizing the box to its content instead:
 
 ````
 ```lean -stretch
@@ -414,11 +414,11 @@ def answer : Nat := 42
 ```
 ````
 
-`reveal.js` can only stretch one element per slide. If a slide has more
-than one code box, add `-stretch` to all but one of them; otherwise the
-heights are computed incorrectly. (The standalone `:::stretch` directive,
-documented above, applies the same mechanism to arbitrary content such
-as images.)
+`reveal.js` can only stretch one element per slide. If a slide has
+more than one code box, add `-stretch` to all but one of them;
+otherwise the heights are computed incorrectly. (The standalone
+`:::stretch` directive, documented above, applies the same mechanism
+to arbitrary content such as images.)
 
 The `stretch` flag is available on `lean`, `leanModule`, and
 `leanLibCode` code blocks.
@@ -574,8 +574,8 @@ Arguments:
   re-enable explicitly with `+panel`.
 - `stretch`: a flag that determines whether the code box fills the
   remaining vertical space on the slide (default `true`). Disable with
-  `-stretch` to size the box to its content. See [Code Box
-  Sizing](#code-box-sizing).
+  `-stretch` to size the box to its content. See
+  [Code Box Sizing](#code-box-sizing).
 
 Omitting `decl` and the line range shows the entire module.
 

--- a/TestFixtures/Code.lean
+++ b/TestFixtures/Code.lean
@@ -17,8 +17,20 @@ def hello : IO Unit := do
   IO.println "Hello from VersoSlides!"
 ```
 
-```lean
+```lean -stretch
 #check hello
+```
+
+# Stretch Default
+
+```lean
+def stretchedDef : Nat := 1
+```
+
+# Stretch Off
+
+```lean -stretch
+def unstretchedDef : Nat := 1
 ```
 
 # Light Code

--- a/VersoSlides/Basic.lean
+++ b/VersoSlides/Basic.lean
@@ -272,8 +272,12 @@ public inductive BlockExt where
   | wrap (attrs : Array (String × String))
   /-- Elaborated Lean code block with syntax highlighting (fallback when fragmentize fails). -/
   | leanCode (hlExport : String) (panel : Bool)
-  /-- Fragmentized Lean code block, serialized via {lit}`ExportSlideCode`. -/
-  | slideCode (scExport : String) (panel : Bool)
+  /-- Fragmentized Lean code block, serialized via {lit}`ExportSlideCode`.
+
+  When {name}`stretch` is {name}`true` (the default), the rendered box carries
+  reveal.js's {lit}`r-stretch` class so it fills the remaining vertical space on
+  the slide; otherwise it is sized to its content. -/
+  | slideCode (scExport : String) (panel : Bool) (stretch : Bool)
   /-- Non-Lean code block with a language tag for highlight.js. -/
   | otherLanguage (language : String) (code : String)
   /-- Custom CSS block to be injected into the page header. -/

--- a/VersoSlides/InlineLean.lean
+++ b/VersoSlides/InlineLean.lean
@@ -60,15 +60,19 @@ private partial def collectQueryOutput : Highlighted → Array Highlighted
   | .tactics _ _ _ x => collectQueryOutput x
   | _ => #[]
 
-/-- Slides-specific code block configuration, extending {name}`LeanBlockConfig` with a panel toggle. -/
+/--
+Slides-specific code block configuration, extending {name}`LeanBlockConfig` with a panel toggle and
+a vertical-stretch toggle.
+-/
 private structure SlidesLeanBlockConfig extends LeanBlockConfig where
   panel : Bool
+  stretch : Bool
 
 instance : Verso.ArgParse.FromArgs SlidesLeanBlockConfig DocElabM where
-  fromArgs := SlidesLeanBlockConfig.mk <$> Verso.ArgParse.fromArgs <*> .flag `panel true
+  fromArgs := SlidesLeanBlockConfig.mk <$> Verso.ArgParse.fromArgs <*> .flag `panel true <*> .flag `stretch true
 
 /-- Callback for `elabCommands`: produces a `Block.other (BlockExt.slideCode ...)` term. -/
-private def toSlidesHighlightedBlock (panel shouldShow : Bool) (hls : Highlighted)
+private def toSlidesHighlightedBlock (panel stretch shouldShow : Bool) (hls : Highlighted)
     (str : StrLit) : DocElabM Term := do
   if !shouldShow then
     return ← ``(Verso.Doc.Block.concat #[])
@@ -82,7 +86,7 @@ private def toSlidesHighlightedBlock (panel shouldShow : Bool) (hls : Highlighte
   match fragmentize hls.trim with
   | .ok sc =>
     let exported := scToExport sc
-    ``(Verso.Doc.Block.other (VersoSlides.BlockExt.slideCode $(quote exported) $(quote panel)) #[Verso.Doc.Block.code $(quote str.getString)])
+    ``(Verso.Doc.Block.other (VersoSlides.BlockExt.slideCode $(quote exported) $(quote panel) $(quote stretch)) #[Verso.Doc.Block.code $(quote str.getString)])
   | .error msg =>
     throwErrorAt str.raw msg
 
@@ -239,7 +243,7 @@ where
 /-- Elaborated Lean code block for slides (with format data collection). -/
 @[code_block]
 def lean : CodeBlockExpanderOf SlidesLeanBlockConfig
-  | config, str => elabCommandsWithFormat config.toLeanBlockConfig str (toSlidesHighlightedBlock config.panel)
+  | config, str => elabCommandsWithFormat config.toLeanBlockConfig str (toSlidesHighlightedBlock config.panel config.stretch)
 
 /-- Inline elaborated Lean command for slides (with format data collection). -/
 @[role]

--- a/VersoSlides/LibModule.lean
+++ b/VersoSlides/LibModule.lean
@@ -49,6 +49,8 @@ structure LibModuleConfig where
   endLine : Option Nat := none
   /-- Whether to show the interactive info panel below the slide. -/
   panel : Bool := true
+  /-- Whether the code box fills the remaining vertical space on the slide. -/
+  stretch : Bool := true
 
 section
 
@@ -63,6 +65,7 @@ instance : FromArgs LibModuleConfig m where
       <*> .named `startLine .nat true
       <*> .named `endLine .nat true
       <*> .flag `panel true
+      <*> .flag `stretch true
 end
 
 /-- Cached extracted module JSON, keyed by fully-qualified module name. -/
@@ -477,7 +480,8 @@ def leanLibCode : CodeBlockExpanderOf LibModuleConfig
                 cfg.package.map (s!"(package := {·.getId})"),
                 some s!"(startLine := {newSl})",
                 some s!"(endLine := {newEl})",
-                if !cfg.panel then some "-panel" else none
+                if !cfg.panel then some "-panel" else none,
+                if !cfg.stretch then some "-stretch" else none
               ]
               editCodeBlock ref (some (" ".intercalate (newArgs.filterMap id))) newContents
             else pure none
@@ -499,7 +503,7 @@ def leanLibCode : CodeBlockExpanderOf LibModuleConfig
     | .ok sc =>
       let exported := scToExport sc
       ``(Verso.Doc.Block.other
-           (VersoSlides.BlockExt.slideCode $(quote exported) $(quote cfg.panel))
+           (VersoSlides.BlockExt.slideCode $(quote exported) $(quote cfg.panel) $(quote cfg.stretch))
            #[Verso.Doc.Block.code $(quote str.getString)])
     | .error msg =>
       throwErrorAt str.raw msg

--- a/VersoSlides/ModuleExample.lean
+++ b/VersoSlides/ModuleExample.lean
@@ -44,6 +44,7 @@ structure ModuleConfig where
   error : Bool := false
   «show» : Bool := true
   panel : Bool := true
+  stretch : Bool := true
   lakefile : Bool := false
 
 section
@@ -51,7 +52,7 @@ section
 variable [Monad m] [MonadError m]
 
 instance : FromArgs ModuleConfig m where
-  fromArgs := ModuleConfig.mk <$> .named' `name true <*> .named' `moduleName true <*> .flag `error false <*> .flag `show true <*> .flag `panel true <*> .flag `lakefile false
+  fromArgs := ModuleConfig.mk <$> .named' `name true <*> .named' `moduleName true <*> .flag `error false <*> .flag `show true <*> .flag `panel true <*> .flag `stretch true <*> .flag `lakefile false
 
 end
 
@@ -107,7 +108,7 @@ def lineStx [Monad m] [MonadFileMap m] (l : Nat) : m Syntax := do
 open Lean.Doc.Syntax in
 @[code_block]
 def leanModule : CodeBlockExpanderOf ModuleConfig
-  | { name, moduleName, error, «show», panel, lakefile }, str => do
+  | { name, moduleName, error, «show», panel, stretch, lakefile }, str => do
     let line := (← getFileMap).utf8PosToLspPos str.raw.getPos! |>.line
     let leanCode := line.fold (fun _ _ s => s.push '\n') "" ++ str.getString ++ "\n"
     let hl ← IO.FS.withTempDir fun dirname => do
@@ -206,7 +207,7 @@ def leanModule : CodeBlockExpanderOf ModuleConfig
       match fragmentize hl.trim with
       | .ok sc =>
         let exported := scToExport sc
-        ``(Verso.Doc.Block.other (VersoSlides.BlockExt.slideCode $(quote exported) $(quote panel))
+        ``(Verso.Doc.Block.other (VersoSlides.BlockExt.slideCode $(quote exported) $(quote panel) $(quote stretch))
             #[Verso.Doc.Block.code $(quote str.getString)])
       | .error msg =>
         throwErrorAt str.raw msg
@@ -445,7 +446,7 @@ def leanModules : DirectiveExpanderOf ModulesConfig
             | .ok sc =>
               let exported := scToExport sc
               ``((Verso.Doc.Block.other
-                  (VersoSlides.BlockExt.slideCode $(quote exported) $(quote modConfig.panel))
+                  (VersoSlides.BlockExt.slideCode $(quote exported) $(quote modConfig.panel) $(quote modConfig.stretch))
                   #[Verso.Doc.Block.code $(quote s.getString)] : Verso.Doc.Block Slides))
             | .error msg =>
               throwErrorAt blame msg

--- a/VersoSlides/Render.lean
+++ b/VersoSlides/Render.lean
@@ -112,10 +112,14 @@ instance [Monad m] : GenreHtml Slides m where
     | .wrap attrs =>
       let inner ← contents.mapM blockHtml
       pure (.tag "div" attrs (.seq inner))
-    | .slideCode scExport panel =>
+    | .slideCode scExport panel stretch =>
       let sc := scFromExport! scExport
       let codeHtml ← pure {{ <code class="hl lean block"> {{ ← sc.toHtml (g := Slides) }} </code> }}
-      pure (wrapWithPanel codeHtml panel)
+      let wrapped := wrapWithPanel codeHtml panel
+      -- When stretched, add reveal.js's `r-stretch` class to the outermost element
+      -- (the `.code-with-panel` div, or the bare `<code>`) so it fills the slide's
+      -- remaining vertical space. `addClassToHtml` only touches the top-level tag.
+      pure (if stretch then addClassToHtml "r-stretch" wrapped else wrapped)
     | .leanCode hlExport panel =>
       let hl := (hlFromExport! hlExport).trim
       let codeHtml ← match fragmentize hl with

--- a/browser-tests/test_code.py
+++ b/browser-tests/test_code.py
@@ -5,12 +5,16 @@ from playwright.sync_api import Page
 from conftest import goto_slide_by_title
 
 
-def _block_in_section(doc: BeautifulSoup, title: str):
-    """Return the first code.hl.lean.block inside the slide with the given title."""
+def _code_box_in_section(doc: BeautifulSoup, title: str):
+    """Return the outermost code-box element on the slide with the given title.
+
+    With the info panel on (the default), the stretch class lands on the
+    ``.code-with-panel`` wrapper; without it, on the bare ``code.hl.lean.block``.
+    """
     for s in doc.select("section"):
         h = s.select_one("h1, h2, h3")
         if h and h.get_text().strip() == title:
-            return s.select_one("code.hl.lean.block")
+            return s.select_one(".code-with-panel") or s.select_one("code.hl.lean.block")
     return None
 
 
@@ -59,15 +63,15 @@ class TestCodeBlocks:
 
     def test_stretch_default_has_class(self, code_doc: BeautifulSoup):
         """A code box defaults to filling vertical space (carries r-stretch)."""
-        block = _block_in_section(code_doc, "Stretch Default")
-        assert block is not None, "Stretch Default slide not found"
-        assert "r-stretch" in block.get("class", [])
+        box = _code_box_in_section(code_doc, "Stretch Default")
+        assert box is not None, "Stretch Default slide not found"
+        assert "r-stretch" in box.get("class", [])
 
     def test_stretch_off_omits_class(self, code_doc: BeautifulSoup):
         """The -stretch flag opts out, so the box is content-sized (no r-stretch)."""
-        block = _block_in_section(code_doc, "Stretch Off")
-        assert block is not None, "Stretch Off slide not found"
-        assert "r-stretch" not in block.get("class", [])
+        box = _code_box_in_section(code_doc, "Stretch Off")
+        assert box is not None, "Stretch Off slide not found"
+        assert "r-stretch" not in box.get("class", [])
 
     def test_error_block_renders(self, code_doc: BeautifulSoup):
         """A code block with +error should render with error diagnostics as warnings."""

--- a/browser-tests/test_code.py
+++ b/browser-tests/test_code.py
@@ -1,6 +1,17 @@
 """Static HTML tests for elaborated Lean code blocks."""
 
 from bs4 import BeautifulSoup
+from playwright.sync_api import Page
+from conftest import goto_slide_by_title
+
+
+def _block_in_section(doc: BeautifulSoup, title: str):
+    """Return the first code.hl.lean.block inside the slide with the given title."""
+    for s in doc.select("section"):
+        h = s.select_one("h1, h2, h3")
+        if h and h.get_text().strip() == title:
+            return s.select_one("code.hl.lean.block")
+    return None
 
 
 class TestCodeBlocks:
@@ -46,6 +57,18 @@ class TestCodeBlocks:
         info_spans = code_doc.select("code.hl.lean.block .has-info.information")
         assert len(info_spans) >= 2  # #check hello, #eval greet "Lean"
 
+    def test_stretch_default_has_class(self, code_doc: BeautifulSoup):
+        """A code box defaults to filling vertical space (carries r-stretch)."""
+        block = _block_in_section(code_doc, "Stretch Default")
+        assert block is not None, "Stretch Default slide not found"
+        assert "r-stretch" in block.get("class", [])
+
+    def test_stretch_off_omits_class(self, code_doc: BeautifulSoup):
+        """The -stretch flag opts out, so the box is content-sized (no r-stretch)."""
+        block = _block_in_section(code_doc, "Stretch Off")
+        assert block is not None, "Stretch Off slide not found"
+        assert "r-stretch" not in block.get("class", [])
+
     def test_error_block_renders(self, code_doc: BeautifulSoup):
         """A code block with +error should render with error diagnostics as warnings."""
         # Find the slide titled "Expected Error"
@@ -63,3 +86,32 @@ class TestCodeBlocks:
         # Should contain the #check token
         tokens = code_block.get_text()
         assert "#check" in tokens
+
+
+class TestStretchLayout:
+    """Browser-rendered layout tests for the vertical-stretch behaviour."""
+
+    def _heights(self, page: Page, code_url: str, title: str):
+        """Return (code box height, enclosing section height) in on-screen px."""
+        section = goto_slide_by_title(page, code_url, title)
+        section_box = section.bounding_box()
+        code_box = section.locator("code.hl.lean.block").first.bounding_box()
+        assert code_box is not None, f"Code box not visible on slide '{title}'"
+        assert section_box is not None, f"Section not visible on slide '{title}'"
+        return code_box["height"], section_box["height"]
+
+    def test_stretched_box_fills_more_than_content(self, code_url: str, page: Page):
+        """The default (stretched) box is much taller than the same one-line
+        snippet rendered with -stretch, and fills a large share of the slide."""
+        stretched, section_h = self._heights(page, code_url, "Stretch Default")
+        unstretched, _ = self._heights(page, code_url, "Stretch Off")
+        # Both boxes hold a single short def; stretched should be far taller.
+        assert stretched > unstretched * 3, (
+            f"stretched={stretched} not much taller than unstretched={unstretched}"
+        )
+        # The stretched box should fill a large fraction of its slide. The
+        # section and the box are scaled by the same reveal transform, so the
+        # ratio is independent of the on-screen scale.
+        assert stretched > section_h * 0.5, (
+            f"stretched box height {stretched} did not fill section height {section_h}"
+        )

--- a/browser-tests/test_fragments.py
+++ b/browser-tests/test_fragments.py
@@ -1,16 +1,15 @@
 """Browser tests for fragment effects on code blocks."""
 
 from playwright.sync_api import expect, Page
-from conftest import wait_for_reveal_ready
+from conftest import goto_slide_by_title
 
 
 class TestFragmentTransform:
     def test_span_fragment_inline_block(self, code_url: str, page: Page):
         """Span fragments inside code should have display: inline-block for transforms."""
-        page.goto(f"{code_url}/index.html#/4")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Fragment Effects")
 
-        span_frag = page.locator("code.hl.lean.block span.fragment").first
+        span_frag = slide.locator("code.hl.lean.block span.fragment").first
         if span_frag.count() == 0:
             return  # skip if no span fragments
 
@@ -19,10 +18,9 @@ class TestFragmentTransform:
 
     def test_div_fragment_not_inline_block(self, code_url: str, page: Page):
         """Div fragments inside code should NOT be inline-block (preserves line structure)."""
-        page.goto(f"{code_url}/index.html#/4")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Fragment Effects")
 
-        div_frag = page.locator("code.hl.lean.block div.fragment").first
+        div_frag = slide.locator("code.hl.lean.block div.fragment").first
         if div_frag.count() == 0:
             return  # skip if no div fragments
 
@@ -31,11 +29,10 @@ class TestFragmentTransform:
 
     def test_grow_fragment_scales(self, code_url: str, page: Page):
         """A visible .fragment.grow should have a scale transform."""
-        page.goto(f"{code_url}/index.html#/4")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Fragment Effects")
 
         # Advance fragments to make the grow fragment visible
-        grow = page.locator(".fragment.grow").first
+        grow = slide.locator(".fragment.grow").first
         if grow.count() == 0:
             return
 
@@ -58,10 +55,9 @@ class TestFragmentTransform:
 class TestFragmentColor:
     def test_highlight_current_red_changes_token_color(self, code_url: str, page: Page):
         """A .fragment.highlight-current-red.current-fragment should override token colors."""
-        page.goto(f"{code_url}/index.html#/4")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Fragment Effects")
 
-        red_frag = page.locator(".fragment.highlight-current-red").first
+        red_frag = slide.locator(".fragment.highlight-current-red").first
         if red_frag.count() == 0:
             return
 
@@ -89,10 +85,9 @@ class TestFragmentColor:
 
     def test_token_color_inherits_from_fragment(self, code_url: str, page: Page):
         """When a color fragment is active, descendant tokens should use color: inherit."""
-        page.goto(f"{code_url}/index.html#/4")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Fragment Effects")
 
-        red_frag = page.locator(".fragment.highlight-current-red").first
+        red_frag = slide.locator(".fragment.highlight-current-red").first
         if red_frag.count() == 0:
             return
 

--- a/browser-tests/test_interactive.py
+++ b/browser-tests/test_interactive.py
@@ -1,17 +1,16 @@
 """Browser tests for JS-dependent features (info panel, adaptive backgrounds)."""
 
 from playwright.sync_api import expect, Page
-from conftest import wait_for_reveal_ready
+from conftest import goto_slide_by_title
 
 
 class TestInfoPanel:
     def test_click_shows_hover_info(self, code_url: str, page: Page):
         """Clicking a token with data-verso-hover should populate the info panel."""
-        page.goto(f"{code_url}/index.html#/0")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Dark Code")
 
         # Find the panel block
-        block = page.locator(".code-with-panel").first
+        block = slide.locator(".code-with-panel").first
         panel = block.locator(".info-panel")
         expect(panel).to_be_visible()
 
@@ -26,10 +25,9 @@ class TestInfoPanel:
 
     def test_docstring_markdown(self, code_url: str, page: Page):
         """Clicking IO.println should show a rendered docstring with HTML in the panel."""
-        page.goto(f"{code_url}/index.html#/0")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Dark Code")
 
-        block = page.locator(".code-with-panel").first
+        block = slide.locator(".code-with-panel").first
         panel = block.locator(".info-panel")
 
         # Find IO.println token by text and click it
@@ -48,20 +46,16 @@ class TestInfoPanel:
 class TestAdaptiveBackground:
     def test_code_bg_dark_slide(self, code_url: str, page: Page):
         """On a dark-themed slide, code blocks should have a light semi-transparent bg."""
-        page.goto(f"{code_url}/index.html#/0")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Dark Code")
 
-        slide = page.locator(".slides > section").first
         code_block = slide.locator("code.hl.lean.block").first
         bg = code_block.evaluate("el => el.style.background")
         assert "255" in bg and "0.08" in bg, f"Expected light overlay, got: {bg}"
 
     def test_code_bg_light_slide(self, code_url: str, page: Page):
         """On a light-background slide, code blocks should have a dark semi-transparent bg."""
-        page.goto(f"{code_url}/index.html#/1")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Light Code")
 
-        slide = page.locator("section[data-background-color='#f5f5f5']")
         code_block = slide.locator("code.hl.lean.block").first
         bg = code_block.evaluate("el => el.style.background")
         assert "0, 0, 0" in bg, f"Expected dark overlay, got: {bg}"

--- a/browser-tests/test_lightbox.py
+++ b/browser-tests/test_lightbox.py
@@ -1,17 +1,16 @@
 """Browser tests for the inline Lean term lightbox overlay."""
 
 from playwright.sync_api import expect, Page
-from conftest import goto_slide_by_title, wait_for_reveal_ready
+from conftest import goto_slide_by_title
 
 
 class TestLightboxOpen:
     def test_click_inline_token_opens_lightbox(self, code_url: str, page: Page):
         """Clicking a data-verso-hover token in inline code should open a lightbox."""
-        page.goto(f"{code_url}/index.html#/3")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Inline Lean")
 
         # Find an inline lean code element
-        inline = page.locator("code.hl.lean.inline").first
+        inline = slide.locator("code.hl.lean.inline").first
         expect(inline).to_be_visible()
 
         # Click a token with hover data inside it
@@ -26,10 +25,9 @@ class TestLightboxOpen:
 
     def test_lightbox_has_content(self, code_url: str, page: Page):
         """The lightbox should contain hover information."""
-        page.goto(f"{code_url}/index.html#/3")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Inline Lean")
 
-        token = page.locator("code.hl.lean.inline [data-verso-hover]").first
+        token = slide.locator("code.hl.lean.inline [data-verso-hover]").first
         token.click()
         page.wait_for_timeout(500)
 
@@ -39,10 +37,9 @@ class TestLightboxOpen:
 
     def test_lightbox_monospace_font(self, code_url: str, page: Page):
         """Lightbox content should use a monospace font."""
-        page.goto(f"{code_url}/index.html#/3")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Inline Lean")
 
-        token = page.locator("code.hl.lean.inline [data-verso-hover]").first
+        token = slide.locator("code.hl.lean.inline [data-verso-hover]").first
         token.click()
         page.wait_for_timeout(500)
 
@@ -54,9 +51,8 @@ class TestLightboxOpen:
 class TestLightboxClose:
     def _open_lightbox(self, page: Page, code_url: str):
         """Helper to navigate and open a lightbox."""
-        page.goto(f"{code_url}/index.html#/3")
-        wait_for_reveal_ready(page)
-        token = page.locator("code.hl.lean.inline [data-verso-hover]").first
+        slide = goto_slide_by_title(page, code_url, "Inline Lean")
+        token = slide.locator("code.hl.lean.inline [data-verso-hover]").first
         token.click()
         page.wait_for_timeout(500)
         expect(page.locator(".r-overlay-lean-hover")).to_be_visible()
@@ -102,10 +98,9 @@ class TestLightboxClose:
 class TestLightboxSizing:
     def test_lightbox_width(self, code_url: str, page: Page):
         """Lightbox should be 75% of the slide width."""
-        page.goto(f"{code_url}/index.html#/3")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Inline Lean")
 
-        token = page.locator("code.hl.lean.inline [data-verso-hover]").first
+        token = slide.locator("code.hl.lean.inline [data-verso-hover]").first
         token.click()
         page.wait_for_timeout(500)
 
@@ -119,10 +114,9 @@ class TestLightboxSizing:
 
     def test_lightbox_scrollable_when_tall(self, code_url: str, page: Page):
         """Lightbox with overflow-y: auto should allow scrolling if content is tall."""
-        page.goto(f"{code_url}/index.html#/3")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Inline Lean")
 
-        token = page.locator("code.hl.lean.inline [data-verso-hover]").first
+        token = slide.locator("code.hl.lean.inline [data-verso-hover]").first
         token.click()
         page.wait_for_timeout(500)
 
@@ -205,10 +199,9 @@ class TestLightboxThemeColors:
 class TestTippySuppression:
     def test_no_tippy_on_inline_code(self, code_url: str, page: Page):
         """Hovering an inline Lean token should not create a Tippy tooltip."""
-        page.goto(f"{code_url}/index.html#/3")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Inline Lean")
 
-        token = page.locator("code.hl.lean.inline [data-verso-hover]").first
+        token = slide.locator("code.hl.lean.inline [data-verso-hover]").first
         expect(token).to_be_visible()
         token.hover()
         page.wait_for_timeout(500)

--- a/browser-tests/test_panel.py
+++ b/browser-tests/test_panel.py
@@ -1,16 +1,15 @@
 """Browser tests for the interactive info panel."""
 
 from playwright.sync_api import expect, Page
-from conftest import wait_for_reveal_ready
+from conftest import goto_slide_by_title
 
 
 class TestPanelStructure:
     def test_panel_wrapper_exists(self, code_url: str, page: Page):
         """.code-with-panel wrapper should exist around lean code blocks."""
-        page.goto(f"{code_url}/index.html#/0")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Dark Code")
 
-        panels = page.locator(".code-with-panel")
+        panels = slide.locator(".code-with-panel")
         assert panels.count() >= 1
 
         # Each wrapper should have code, divider, and info-panel
@@ -21,11 +20,7 @@ class TestPanelStructure:
 
     def test_no_panel_flag(self, code_url: str, page: Page):
         """lean -panel should render a code block without the panel wrapper."""
-        # "No Panel" is slide index 5
-        page.goto(f"{code_url}/index.html#/5")
-        wait_for_reveal_ready(page)
-
-        slide = page.locator(".slides > section").nth(5)
+        slide = goto_slide_by_title(page, code_url, "No Panel")
         # Should have a Lean code block
         code_block = slide.locator("code.hl.lean.block")
         expect(code_block).to_be_visible()
@@ -39,10 +34,9 @@ class TestPanelStructure:
 
     def test_panel_starts_empty(self, code_url: str, page: Page):
         """.info-panel should start with no content."""
-        page.goto(f"{code_url}/index.html#/0")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Dark Code")
 
-        panel = page.locator(".code-with-panel .info-panel").first
+        panel = slide.locator(".code-with-panel .info-panel").first
         expect(panel).to_be_visible()
         assert panel.inner_html().strip() == ""
 
@@ -50,11 +44,7 @@ class TestPanelStructure:
 class TestTacticReflow:
     def test_tactic_goals_reflow_on_resize(self, code_url: str, page: Page):
         """Clicking a tactic should show reflowed goals that re-render when the panel resizes."""
-        page.goto(f"{code_url}/index.html#/2")
-        wait_for_reveal_ready(page)
-
-        # Scope to the active slide (index 2 = Proof slide)
-        slide = page.locator(".slides > section").nth(2)
+        slide = goto_slide_by_title(page, code_url, "Proof")
         block = slide.locator(".code-with-panel").first
         panel = block.locator(".info-panel")
 
@@ -96,10 +86,9 @@ class TestTacticReflow:
 class TestPanelInteraction:
     def test_click_populates_panel(self, code_url: str, page: Page):
         """Clicking a [data-verso-hover] token should populate the panel."""
-        page.goto(f"{code_url}/index.html#/0")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Dark Code")
 
-        block = page.locator(".code-with-panel").first
+        block = slide.locator(".code-with-panel").first
         panel = block.locator(".info-panel")
         token = block.locator("[data-verso-hover]").first
         expect(token).to_be_visible()
@@ -110,10 +99,9 @@ class TestPanelInteraction:
 
     def test_click_adds_panel_focus(self, code_url: str, page: Page):
         """Clicking a token should add .panel-focus class to it."""
-        page.goto(f"{code_url}/index.html#/0")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Dark Code")
 
-        block = page.locator(".code-with-panel").first
+        block = slide.locator(".code-with-panel").first
         token = block.locator("[data-verso-hover]").first
         token.click()
         page.wait_for_timeout(300)
@@ -124,10 +112,9 @@ class TestPanelInteraction:
 
     def test_binding_highlight(self, code_url: str, page: Page):
         """Hovering a token with data-binding should toggle .binding-hl on matching tokens."""
-        page.goto(f"{code_url}/index.html#/0")
-        wait_for_reveal_ready(page)
+        slide = goto_slide_by_title(page, code_url, "Dark Code")
 
-        block = page.locator(".code-with-panel").first
+        block = slide.locator(".code-with-panel").first
         code = block.locator("code.hl.lean.block")
 
         # Find a token with data-binding

--- a/browser-tests/test_slides.py
+++ b/browser-tests/test_slides.py
@@ -43,8 +43,14 @@ class TestSlideStructure:
         slides_div = markup_doc.select_one("div.slides")
         top_sections = slides_div.find_all("section", recursive=False)
 
-        # Second section (index 1) is "Vertical Section"
-        vertical_section = top_sections[1]
+        # Locate the "Vertical Section" group by its heading rather than by position.
+        vertical_section = None
+        for sec in top_sections:
+            heading = sec.find(["h1", "h2"])
+            if heading and heading.get_text(strip=True) == "Vertical Section":
+                vertical_section = sec
+                break
+        assert vertical_section is not None, "Vertical Section slide not found"
         inner_sections = vertical_section.find_all("section", recursive=False)
         assert len(inner_sections) == 3  # implicit first + Sub A + Sub B
 

--- a/web-lib/panel/panel.css
+++ b/web-lib/panel/panel.css
@@ -8,6 +8,22 @@
     margin: 0.5em auto;
 }
 
+/* Stretched (default) panel: reveal.js sets an explicit inline height on the
+   grid container. Make the single row fill that height (minmax(0, 1fr) so it
+   can also shrink) and restore the centered 95% width over reveal's inline
+   full width. The grid's align-items: stretch fills the code and panel cells. */
+.code-with-panel.r-stretch {
+    grid-template-rows: minmax(0, 1fr);
+    width: 95% !important;
+    max-width: 95% !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+}
+.code-with-panel.r-stretch > code.hl.lean.block {
+    min-height: 0;
+    overflow-y: auto;
+}
+
 /* Code block inside panel — override standalone margins/shadow */
 .code-with-panel > code.hl.lean.block {
     margin: 0;

--- a/web-lib/panel/slides-highlight.css
+++ b/web-lib/panel/slides-highlight.css
@@ -12,6 +12,17 @@
     max-width: 95%;
     overflow-x: auto;
 }
+/* Stretched (default) bare code box: reveal.js sets an explicit inline height
+   so the box fills the slide's remaining vertical space. reveal also sets an
+   inline full width, so restore the centered 95% with !important (a stylesheet
+   !important beats a non-important inline declaration). Tall code scrolls. */
+.reveal code.hl.lean.block.r-stretch {
+    width: 95% !important;
+    max-width: 95% !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    overflow-y: auto;
+}
 .reveal code.hl.lean.inline {
     font-size: 0.9em;
     background: rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
Adds a `stretch` flag to Lean code boxes, defaulting to `true`, that causes them to take up maximal space.