### PR TITLE
feat: add an option verso.slides.panel that controls info panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,34 @@ to arbitrary content such as images.)
 The `stretch` flag is available on `lean`, `leanModule`, and
 `leanLibCode` code blocks.
 
+### Info Panel
+
+By default, each code box includes an interactive information panel.
+Clicking on part of the code reveals its type, proof state, and/or
+documentation in the panel. Pass the `-panel` flag to omit the panel
+from a single code box. If panels are disabled, use `+panel` to
+re-enable it.
+
+````
+```lean -panel
+def answer : Nat := 42
+```
+````
+
+To change the default for an entire slide show, set the
+`verso.slides.panel` option at the top of the file. It defaults to
+`true`:
+
+```lean
+set_option verso.slides.panel false
+
+#doc (Slides) "My Talk" =>
+...
+```
+
+The `panel` flag and the `verso.slides.panel` option apply to `lean`,
+`leanModule`, and `leanLibCode` code blocks.
+
 ### Tips
 
 Use the `-show` flag to include Lean code that is not rendered. This

--- a/TestFixtures/Build.lean
+++ b/TestFixtures/Build.lean
@@ -7,6 +7,7 @@ import VersoSlides
 import VersoUtil.BinFiles
 import TestFixtures.Markup
 import TestFixtures.Code
+import TestFixtures.PanelOption
 import TestFixtures.DiagramAnim
 import TestFixtures.Theme
 import TestFixtures.MinimalThemed
@@ -47,6 +48,10 @@ def main : IO UInt32 := do
   let rc ← slidesMain
     { theme := "black", outputDir := "_test/code" }
     (%doc TestFixtures.Code)
+  if rc != 0 then return rc
+  let rc ← slidesMain
+    { theme := "black", outputDir := "_test/paneloption" }
+    (%doc TestFixtures.PanelOption)
   if rc != 0 then return rc
   let rc ← slidesMain
     { theme := "black", outputDir := "_test/diagramanim" }

--- a/TestFixtures/PanelOption.lean
+++ b/TestFixtures/PanelOption.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+import VersoSlides
+import Verso.Doc.Concrete
+
+open VersoSlides
+
+-- Setting this option to `false` makes flag-less code boxes render without a
+-- panel; individual boxes can still opt back in with `+panel`.
+set_option verso.slides.panel false
+
+#doc (Slides) "Panel Option Fixture" =>
+
+# Panel Off By Default
+
+```lean
+def optNoPanelDef : Nat := 1
+```
+
+```lean +panel -stretch
+def optPanelDef : Nat := 2
+```

--- a/VersoSlides/InlineLean.lean
+++ b/VersoSlides/InlineLean.lean
@@ -20,7 +20,22 @@ open Verso.Genre.Manual.InlineLean.Scopes (getScopes setScopes runWithOpenDecls 
 open Verso (withoutAsync)
 open Lean.Doc.Syntax
 
+register_option verso.slides.panel : Bool := {
+  defValue := true
+  descr := "default value for the `panel` flag on Lean code boxes, which determines whether to show the interactive info panel"
+}
+
 namespace VersoSlides
+
+/--
+An `ArgParse` parser for the `panel` flag shared by all code-box directives. Its default is taken
+from the `verso.slides.panel` option (which itself defaults to `true`), so a document can flip the
+default with `set_option verso.slides.panel false` while individual boxes still override it with
+`+panel`/`-panel`.
+-/
+def panelFlag [Monad m] [MonadOptions m] : Verso.ArgParse m Bool :=
+  .flagM `panel (return (← getOptions).getBool `verso.slides.panel true)
+    (doc? := "whether to show the interactive info panel below the code box (defaults to the value of the `verso.slides.panel` option)")
 
 /-- Syntax node kinds whose output should be rendered inline after the command. -/
 private def queryCommandKinds : Array SyntaxNodeKind :=
@@ -68,8 +83,12 @@ private structure SlidesLeanBlockConfig extends LeanBlockConfig where
   panel : Bool
   stretch : Bool
 
-instance : Verso.ArgParse.FromArgs SlidesLeanBlockConfig DocElabM where
-  fromArgs := SlidesLeanBlockConfig.mk <$> Verso.ArgParse.fromArgs <*> .flag `panel true <*> .flag `stretch true
+open Verso ArgParse in
+instance : FromArgs SlidesLeanBlockConfig DocElabM where
+  fromArgs := SlidesLeanBlockConfig.mk <$>
+    fromArgs <*>
+    panelFlag <*>
+    .flag `stretch true
 
 /-- Callback for `elabCommands`: produces a `Block.other (BlockExt.slideCode ...)` term. -/
 private def toSlidesHighlightedBlock (panel stretch shouldShow : Bool) (hls : Highlighted)

--- a/VersoSlides/LibModule.lean
+++ b/VersoSlides/LibModule.lean
@@ -54,7 +54,7 @@ structure LibModuleConfig where
 
 section
 
-variable [Monad m] [MonadError m]
+variable [Monad m] [MonadError m] [MonadOptions m]
 
 instance : FromArgs LibModuleConfig m where
   fromArgs :=
@@ -64,7 +64,7 @@ instance : FromArgs LibModuleConfig m where
       <*> .named `decl .ident true
       <*> .named `startLine .nat true
       <*> .named `endLine .nat true
-      <*> .flag `panel true
+      <*> panelFlag
       <*> .flag `stretch true
 end
 

--- a/VersoSlides/ModuleExample.lean
+++ b/VersoSlides/ModuleExample.lean
@@ -49,10 +49,17 @@ structure ModuleConfig where
 
 section
 
-variable [Monad m] [MonadError m]
+variable [Monad m] [MonadError m] [MonadOptions m]
 
 instance : FromArgs ModuleConfig m where
-  fromArgs := ModuleConfig.mk <$> .named' `name true <*> .named' `moduleName true <*> .flag `error false <*> .flag `show true <*> .flag `panel true <*> .flag `stretch true <*> .flag `lakefile false
+  fromArgs := ModuleConfig.mk <$>
+    .named' `name true <*>
+    .named' `moduleName true <*>
+    .flag `error false <*>
+    .flag `show true <*>
+    panelFlag <*>
+    .flag `stretch true <*>
+    .flag `lakefile false
 
 end
 

--- a/browser-tests/conftest.py
+++ b/browser-tests/conftest.py
@@ -119,6 +119,15 @@ def code_doc(site_dir):
 
 
 @pytest.fixture(scope="session")
+def paneloption_doc(site_dir):
+    """Parse _test/paneloption/index.html with BeautifulSoup (panel-option fixture)."""
+    html_path = site_dir / "paneloption" / "index.html"
+    assert html_path.exists(), f"Panel-option fixture not found at {html_path}. Run 'lake exe test-fixtures-build' first."
+    with open(html_path) as f:
+        return BeautifulSoup(f.read(), "html.parser")
+
+
+@pytest.fixture(scope="session")
 def diagramanim_doc(site_dir):
     """Parse _test/diagramanim/index.html with BeautifulSoup (diagram/animation fixture)."""
     html_path = site_dir / "diagramanim" / "index.html"
@@ -174,6 +183,12 @@ def markup_url(server):
 def code_url(server):
     """Base URL for the code fixture."""
     return f"{server}/code"
+
+
+@pytest.fixture(scope="session")
+def paneloption_url(server):
+    """Base URL for the panel-option fixture."""
+    return f"{server}/paneloption"
 
 
 @pytest.fixture(scope="session")

--- a/browser-tests/test_panel.py
+++ b/browser-tests/test_panel.py
@@ -32,6 +32,24 @@ class TestPanelStructure:
         # The code block should contain the definition
         assert "noPanelDef" in code_block.inner_text()
 
+    def test_panel_option_default(self, paneloption_url: str, page: Page):
+        """set_option verso.slides.panel false drops the panel from flag-less
+        boxes, while +panel still opts an individual box back in."""
+        slide = goto_slide_by_title(page, paneloption_url, "Panel Off By Default")
+
+        # The flag-less box (optNoPanelDef) should have no panel wrapper.
+        no_panel = slide.locator(
+            ".code-with-panel", has=page.get_by_text("optNoPanelDef")
+        )
+        assert no_panel.count() == 0
+
+        # The +panel box (optPanelDef) should still be wrapped in a panel.
+        with_panel = slide.locator(
+            ".code-with-panel", has=page.get_by_text("optPanelDef")
+        )
+        assert with_panel.count() == 1
+        expect(with_panel.locator(".info-panel")).to_be_visible()
+
     def test_panel_starts_empty(self, code_url: str, page: Page):
         """.info-panel should start with no content."""
         slide = goto_slide_by_title(page, code_url, "Dark Code")


### PR DESCRIPTION
This allows slide authors to select whether panels are shown by default.