### PR TITLE
feat: add custom HTML slide blocks

### DIFF
--- a/Demo.lean
+++ b/Demo.lean
@@ -507,6 +507,17 @@ This {attr («data-id» := "morphing-word")}[word] has a custom data attribute.
 This text is styled with custom CSS injected via a `css` code block.
 :::
 
+# Custom HTML
+
+The `html` code block inserts raw trusted HTML into a slide.
+
+```html
+<div class="demo-highlight" data-demo-html="block">Block-level custom HTML</div>
+```
+
+Inline HTML works with the matching role:
+{html}`<span class="demo-highlight" data-demo-html="inline">inline custom HTML</span>`.
+
 # Image Role
 
 The `{image}` role renders an `<img>` tag with configurable width and height. The path to the image is relative to the source file.

--- a/README.md
+++ b/README.md
@@ -250,6 +250,34 @@ This directive is particularly useful for auto-animate element
 matching, where paired elements across adjacent slides need matching
 `data-id` attributes.
 
+### Custom HTML
+
+The `html` code block and inline `{html}` role insert trusted HTML
+directly into the slide body. This is useful for custom widgets or
+markup that is easier to write by hand than through Verso directives.
+
+````
+```html
+<div class="custom-widget" data-state="ready">
+  <button type="button">Run</button>
+</div>
+```
+````
+
+Inline HTML can be inserted with the matching role:
+
+```
+This uses {html}`<span class="custom-widget">inline HTML</span>` in a paragraph.
+```
+
+The HTML body is not escaped or sanitized, so only use it with HTML
+you control. To display HTML source code instead, use the generic
+`code` block with `html` as the language.
+
+Programmatic clients can construct the same custom elements with
+`BlockExt.ofHtml` or `InlineExt.ofHtml`, which carry
+`Verso.Output.Html` values.
+
 ### Tables
 
 The `table` directive renders an HTML `<table>` from a nested list of

--- a/TestFixtures/Markup.lean
+++ b/TestFixtures/Markup.lean
@@ -179,6 +179,14 @@ The fundamental theorem: $`\sum_{k=1}^n k = \frac{n(n+1)}{2}`.
 
 Prelude macro: $`\RR` and display $$`\Hom(A, B) \subseteq \RR`.
 
+# Custom HTML
+
+```html
+<div class="custom-html-hook" data-raw-html="ok"><span>Custom HTML</span></div>
+```
+
+Inline {html}`<span class="custom-inline-html" data-inline-html="ok">custom inline HTML</span>` works too.
+
 # Last Slide
 :::fragment
 A fragment paragraph.

--- a/VersoSlides/Basic.lean
+++ b/VersoSlides/Basic.lean
@@ -5,6 +5,7 @@ Author: David Thrane Christiansen
 -/
 module
 public import Verso.Doc
+public import Verso.Output.Html
 public import VersoSlides.ImgSrc
 public import VersoManual.Html.CssFile
 public import VersoSlidesVendored
@@ -270,6 +271,8 @@ public inductive BlockExt where
   | attr (attrs : Array (String × String))
   /-- Wraps ALL children in a `<div>` with the given attributes. -/
   | wrap (attrs : Array (String × String))
+  /-- Trusted custom HTML inserted directly into the slide body. -/
+  | ofHtml (html : Verso.Output.Html)
   /-- Elaborated Lean code block with syntax highlighting (fallback when fragmentize fails). -/
   | leanCode (hlExport : String) (panel : Bool)
   /-- Fragmentized Lean code block, serialized via {lit}`ExportSlideCode`.
@@ -299,6 +302,8 @@ public inductive InlineExt where
   | styled (attrs : Array (String × String))
   /-- Image with configurable dimensions. All fields determined at elaboration time. -/
   | image (src : ImgSrc) (alt : String) (width : Option String) (height : Option String) (cssClass : Option String)
+  /-- Trusted custom HTML inserted directly into inline content. -/
+  | ofHtml (html : Verso.Output.Html)
   /-- Elaborated inline Lean code with syntax highlighting (fallback when fragmentize fails). -/
   | leanCode (hlExport : String)
   /-- Fragmentized inline Lean code, serialized via {lit}`ExportSlideCode`. -/

--- a/VersoSlides/Directives.lean
+++ b/VersoSlides/Directives.lean
@@ -581,3 +581,39 @@ Usage:
 public meta def css : CodeBlockExpanderOf Unit
   | (), str =>
     ``(Verso.Doc.Block.other (BlockExt.css $(quote str.getString)) #[])
+
+/--
+Custom HTML block. The content is inserted directly into the slide body
+without escaping.
+
+Usage:
+````
+```html
+<div class="custom-widget"></div>
+```
+````
+-/
+@[code_block]
+public meta def html : CodeBlockExpanderOf Unit
+  | (), str => do
+    -- The `false` parameter treats the text as unescaped raw HTML data.
+    let html := Verso.Output.Html.text false str.getString
+    ``(Verso.Doc.Block.other (BlockExt.ofHtml $(quote html)) #[])
+
+/--
+Inline HTML role. Inserts inline code content directly as HTML, without escaping.
+
+Usage:
+```
+This is {html}`<span class="custom-html">custom HTML</span>`.
+```
+-/
+@[role html]
+public meta def htmlRole : RoleExpanderOf Unit
+  | (), inlines => do
+  let #[arg] := inlines
+    | throwError "Expected a single inline code argument"
+  let `(inline|code( $htmlStr:str )) := arg
+    | throwErrorAt arg "Expected inline code"
+  let html := Verso.Output.Html.text false htmlStr.getString
+  ``(Verso.Doc.Inline.other (VersoSlides.InlineExt.ofHtml $(quote html)) #[])

--- a/VersoSlides/Render.lean
+++ b/VersoSlides/Render.lean
@@ -112,6 +112,8 @@ instance [Monad m] [MonadBuildLog (HtmlT Slides m)] : GenreHtml Slides m where
     | .wrap attrs =>
       let inner ← contents.mapM blockHtml
       pure (.tag "div" attrs (.seq inner))
+    | .ofHtml html =>
+      pure html
     | .slideCode scExport panel stretch =>
       let sc := scFromExport! scExport
       let codeHtml ← pure {{ <code class="hl lean block"> {{ ← sc.toHtml (g := Slides) }} </code> }}
@@ -246,6 +248,8 @@ instance [Monad m] [MonadBuildLog (HtmlT Slides m)] : GenreHtml Slides m where
         | (false, none)   => none
       if let some c := classVal then attrs := attrs.push ("class", c)
       pure (.tag "img" attrs .empty)
+    | .ofHtml html =>
+      pure html
     | .slideCode scExport =>
       let sc := scFromExport! scExport
       pure {{ <code class="hl lean inline"> {{ ← sc.toHtml (g := Slides) }} </code> }}

--- a/browser-tests/test_slides.py
+++ b/browser-tests/test_slides.py
@@ -9,7 +9,7 @@ class TestSlideStructure:
         slides_div = markup_doc.select_one("div.slides")
         assert slides_div is not None
         top_sections = slides_div.find_all("section", recursive=False)
-        assert len(top_sections) == 11
+        assert len(top_sections) == 12
 
     def test_slide_titles(self, markup_doc: BeautifulSoup):
         """Each top-level slide should have the expected heading."""
@@ -27,6 +27,7 @@ class TestSlideStructure:
             "CSS Test",
             "Tables",
             "Math",
+            "Custom HTML",
             "Last Slide",
         ]
 
@@ -128,3 +129,19 @@ class TestFragments:
         """Inline fragments should have the correct style classes."""
         assert markup_doc.select_one("span.fragment.highlight-red") is not None
         assert markup_doc.select_one("span.fragment.highlight-blue") is not None
+
+
+class TestCustomHtml:
+    def test_custom_html_block_is_inserted_raw(self, markup_doc: BeautifulSoup):
+        """The `html` code block should insert real HTML, not escaped text."""
+        hook = markup_doc.select_one(".custom-html-hook[data-raw-html='ok']")
+        assert hook is not None
+        child = hook.select_one("span")
+        assert child is not None
+        assert child.get_text(strip=True) == "Custom HTML"
+
+    def test_custom_html_role_is_inserted_raw(self, markup_doc: BeautifulSoup):
+        """The `{html}` role should insert real inline HTML, not escaped text."""
+        hook = markup_doc.select_one(".custom-inline-html[data-inline-html='ok']")
+        assert hook is not None
+        assert hook.get_text(strip=True) == "custom inline HTML"


### PR DESCRIPTION
We add new `BlockExt.ofHtml` and `InlineExt.ofHtml` constructors for inserting trusted `Verso.Output.Html` directly into slides.

Source-level syntax is via fenced `html` code blocks and the inline code-role form `` {html}`...` ``.

README, `Demo.lean`, and fixture/browser coverage have been updated.

I needed this while adding support for Verso Blueprint slides. Another possible design would be to mirror the manual genre block extensibility, so downstream clients could define their own custom block types directly.

Prepared with Codex (GPT-5.5)