### PR TITLE
fix: properly import all of Lake

### DIFF
--- a/ExtractLakefile.lean
+++ b/ExtractLakefile.lean
@@ -4,10 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 import Lean
-import Lake.DSL
 import SubVerso.Compat
 import SubVerso.Highlighting.Code
 import SubVerso.Module
+
+/-
+This import initializes Lake builtins and includes Lake's symbols in the
+symbol table. These are necessary when elaborating `lakefile`s.
+-/
+import Lake -- shake: keep
 
 open SubVerso
 
@@ -70,16 +75,12 @@ unsafe def main (args : List String) : IO UInt32 := do
 
   enableInitializersExecution
 
-  -- Load Lake as a plugin so its builtin_initialize functions (DSL macros, etc.) run.
-  -- This is the same approach the language server uses for lakefile.lean.
-  let lakePlugin := lakeSharedLib sysroot
-
   let contents ← IO.FS.readFile lakefile
   let ictx := Parser.mkInputContext contents lakefile
   let (headerStx, parserState, msgs) ← Parser.parseHeader ictx
   let imports := headerToImports headerStx
 
-  let env ← importModules imports {}  (plugins := #[lakePlugin]) (trustLevel := 1024) (loadExts := true)
+  let env ← importModules imports {} (trustLevel := 1024) (loadExts := true)
   let pctx : Elab.Frontend.Context := {inputCtx := ictx}
 
   let commandState : Command.State := { env, maxRecDepth := defaultMaxRecDepth, messages := msgs }

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -29,7 +29,9 @@ lean_lib Demo where
 
 @[default_target] lean_exe «demo-slides» where root := `Main
 
-lean_exe «extract-lakefile» where root := `ExtractLakefile
+lean_exe «extract-lakefile» where
+  root := `ExtractLakefile
+  supportInterpreter := true
 
 @[test_driver]
 lean_exe «verso-slides-test» where root := `TestMain


### PR DESCRIPTION
...and export the imported Lake from extract-lakefile via supportInterpreter.

The plugin-loading code was copied from code in the server that doesn't import Lake at all, and was incorrect in an executable that *does* import Lake; in this PR we're just importing Lake the way that Lake-the-binary imports Lake-the-library, setting `supportInterpreter := true` so that we can use these symbols to interpret lakefiles, and not loading any plugin.

We could solve the problem on Linux by removing `import Lake.DSL` — that way, Lake symbols only got initialized one time via the plugin mechanism. This did *not* stop the crash on OSX, however! @Vtec234's theory is that even when extract-lakefile is built with `-rdynamic`, the way libLake_shared is compiled on OSX (not using `-undefined dynamic_lookup`), this dynamic library brings along a second copy of libleanshared. At runtime, Linux's dynamic linker resolves libLake's imports against the correct targets — the ones in the extract-lakefile binary — but OSX loads libleanshared again from disk, pointing to the symbols in libLake's copy of libleanshared, which is incorrect and causes objects to move between two copies of mimalloc. The recent update to mimalloc exposed this as a memory-corruption crash.

Adapted from leanprover/downstream-lean4 with help from @datokrat; most of the work here was @Vtec234.