### PR TITLE
fix: better comment on Lake import

### DIFF
--- a/ExtractLakefile.lean
+++ b/ExtractLakefile.lean
@@ -9,8 +9,10 @@ import SubVerso.Highlighting.Code
 import SubVerso.Module
 
 /-
-This import initializes Lake builtins and includes Lake's symbols in the
-symbol table. These are necessary when elaborating `lakefile`s.
+This import initializes Lake builtins AND, in combination with 
+the with `supportInterpreter := true`, option, includes Lake's
+symbols in the symbol table. This lets the executable use Lake's
+symbols when elaborating `lakefiles`.
 -/
 import Lake -- shake: keep
 


### PR DESCRIPTION
I'd left out @Vtec234 's note about the necessity of supportInterpreter := true from my revised comment. I'm still stubbornly rewriting things in my own words but I think this captures more of the original intent.