### PR TITLE
Convert Verso Slides to the module system

### DIFF
--- a/Demo.lean
+++ b/Demo.lean
@@ -3,9 +3,18 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoSlides
-import Verso.Doc.Concrete
-import Illuminate
+
+module
+
+public import VersoSlides
+import Illuminate -- shake: keep
+public meta import VersoSlides.Animate
+public meta import Illuminate.Diagram.Paper
+public meta import Illuminate.Animation.Interpolate
+public meta import Illuminate.Animation.Morph.Evaluate
+public meta import Illuminate.Animation.Morph.Prepare
+public meta import Illuminate.Animation.Easing
+meta import all Init.System.IO
 
 open VersoSlides
 

--- a/ExtractLakefile.lean
+++ b/ExtractLakefile.lean
@@ -3,9 +3,11 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Lean
-import SubVerso.Compat
-import SubVerso.Highlighting.Code
+
+module
+
+import Lean.Elab.Frontend
+import Std.Do.Triple.SpecLemmas
 import SubVerso.Module
 
 /-
@@ -62,7 +64,7 @@ def processArgs (args : List String) : IO Args := do
 where
   fail {α} (msg : String) : IO α := throw <| .userError msg
 
-unsafe def main (args : List String) : IO UInt32 := do
+public unsafe def main (args : List String) : IO UInt32 := do
   let { lakefile, jsonFile, pkgDir } ← processArgs args
 
   let pkgDir : String := Id.run do

--- a/Main.lean
+++ b/Main.lean
@@ -3,12 +3,15 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+
+module
+
 import VersoSlides
 import Demo
 
 open VersoSlides
 
-def main : IO UInt32 :=
+public def main : IO UInt32 :=
   slidesMain
     (config := { theme := "black", slideNumber := true, transition := "slide" })
     (doc := %doc Demo)

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ The document title becomes the HTML page title. Each top-level heading
 slide body.
 
 ```
-import VersoSlides
-import Verso.Doc.Concrete
+module
+
+public import VersoSlides
 
 open VersoSlides
 
@@ -57,6 +58,20 @@ Content of the first slide.
 
 Content of the second slide.
 ```
+
+Slide documents use Lean's module system. `VersoSlides` is imported
+publicly because the generated document declaration exposes Verso
+types to modules that import it. Code inside `#doc` is elaborated
+while that declaration is generated, so APIs used by embedded Lean
+code must also be available at the meta phase. For example, a code
+block that calls `IO.println` needs:
+
+```
+meta import all Init.System.IO
+```
+
+Lean will suggest similarly precise `public meta import` declarations
+when a public document embeds values from another library.
 
 The document module must be imported in `Main.lean`, where the
 `slidesMain` function generates the output. Document-level
@@ -690,12 +705,14 @@ carry per-slide attributes (the table above); doc-level config does
 not appear in `%%%` blocks at all.
 
 ```
+module
+
 import VersoSlides
 import MyPresentation
 
 open VersoSlides
 
-def main : IO UInt32 :=
+public def main : IO UInt32 :=
   slidesMain
     (config := { theme := "white", slideNumber := true,
                  transition := "fade", autoSlide := 5000 })
@@ -787,7 +804,7 @@ def customRevealTheme : CssFile where
   filename := "theme/my-reveal-theme.css"
   contents := ⟨include_str "my-reveal-theme.css"⟩
 
-def main : IO UInt32 :=
+public def main : IO UInt32 :=
   slidesMain
     (config := { theme := .custom customRevealTheme })
     (doc := %doc MyPresentation)
@@ -864,7 +881,7 @@ themes use `monokai`, light themes use `github`, and `solarized` uses
 `solarizedLight`. This default can be overridden:
 
 ```
-def main : IO UInt32 :=
+public def main : IO UInt32 :=
   slidesMain
     (config := { theme := "white", highlightTheme := .githubDark })
     (doc := %doc MyPresentation)
@@ -877,7 +894,7 @@ def myHighlight : HighlightTheme where
   filename := "lib/my-hl.css"
   contents := ⟨include_str "my-hl.css"⟩
 
-def main : IO UInt32 :=
+public def main : IO UInt32 :=
   slidesMain
     (config := { highlightTheme := myHighlight })
     (doc := %doc MyPresentation)
@@ -901,6 +918,8 @@ Use `include_str` to embed the stylesheet at compile time so the
 compiled executable stays self-contained:
 
 ```
+module
+
 import VersoSlides
 import MyPresentation
 
@@ -910,7 +929,7 @@ def myExtraCss : CssFile where
   filename := "custom.css"
   contents := ⟨include_str "custom.css"⟩
 
-def main : IO UInt32 :=
+public def main : IO UInt32 :=
   slidesMain
     (config := { extraCss := #[myExtraCss] })
     (doc := %doc MyPresentation)

--- a/TestElab.lean
+++ b/TestElab.lean
@@ -3,5 +3,8 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+
+module
+
 import TestElab.ErrorReporting
 import TestElab.ImageWarning

--- a/TestElab/ErrorReporting.lean
+++ b/TestElab/ErrorReporting.lean
@@ -10,8 +10,9 @@ Before the fix, a code block with an error (but no +error flag) would throw
 "No error expected in code block, one occurred" in addition to the actual
 Lean error. After the fix, only the actual error is reported.
 -/
-import VersoSlides
-import Verso.Doc.Concrete
+module
+
+public import VersoSlides
 
 open VersoSlides
 

--- a/TestElab/FindBodyLineRange.lean
+++ b/TestElab/FindBodyLineRange.lean
@@ -10,8 +10,8 @@ single `ModuleItem` (range/kind/defines are irrelevant — the function only rea
 `item.code.toString`) and asserts that the returned 1-based source line range matches expectation,
 or `none` when the body is too far from anything in the module.
 -/
-import SubVerso.Module
-import SubVerso.Highlighting.Highlighted
+module
+
 import VersoSlides.LibModule
 
 open SubVerso.Module
@@ -22,14 +22,14 @@ open VersoSlides
 Wraps a string as a single `ModuleItem`. The function under test only looks at `item.code.toString`,
 so the other fields are placeholders.
 -/
-private def mkItem (text : String) : ModuleItem :=
+private meta def mkItem (text : String) : ModuleItem :=
   { range := none, kind := `command, defines := #[], code := .text text }
 
 /-- Convenience wrapper that searches `body` against a single-item array built from `modText`. -/
-private def find (body modText : String) : Option (Nat × Nat × String) :=
+private meta def find (body modText : String) : Option (Nat × Nat × String) :=
   findBodyLineRange body #[mkItem modText]
 
-private def mod5 : String := "module Foo\n\nimport Bar\n\ndef hello := 42\n"
+private meta def mod5 : String := "module Foo\n\nimport Bar\n\ndef hello := 42\n"
 
 -- Exact one-line match.
 /-- info: some (5, 5, "def hello := 42\n") -/

--- a/TestElab/ImageWarning.lean
+++ b/TestElab/ImageWarning.lean
@@ -7,8 +7,9 @@ Author: David Thrane Christiansen
 Tests for the `verso.slides.warnOnImage` option and the `{image}` role's
 alt-text validation.
 -/
-import VersoSlides
-import Verso.Doc.Concrete
+module
+
+public import VersoSlides
 
 open VersoSlides
 

--- a/TestElab/LibCode.lean
+++ b/TestElab/LibCode.lean
@@ -7,8 +7,9 @@ Author: David Thrane Christiansen
 Tests for `leanLibCode`: the code block that shows source from an external
 library module via the `highlighted` Lake facet.
 -/
-import VersoSlides
-import Verso.Doc.Concrete
+module
+
+public import VersoSlides
 
 open VersoSlides
 

--- a/TestFixtures.lean
+++ b/TestFixtures.lean
@@ -3,5 +3,8 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+
+module
+
 import TestFixtures.Markup
 import TestFixtures.Code

--- a/TestFixtures/Build.lean
+++ b/TestFixtures/Build.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoSlides
+
+module
+
 import VersoUtil.BinFiles
 import TestFixtures.Markup
 import TestFixtures.Code
@@ -39,7 +41,7 @@ def hlCustomCss : HighlightTheme where
   filename := "hl/my-hl.css"
   contents := ⟨".hljs { background: #abcdef; }\n"⟩
 
-def main : IO UInt32 := do
+public def main : IO UInt32 := do
   let rc ← slidesMain
     { theme := "black", outputDir := "_test/markup", extraCss := #[markupBannerCss]
       mathPrelude := "\\def\\RR{\\mathbb{R}}\n\\newcommand{\\Hom}[2]{\\mathrm{Hom}(#1, #2)}\n" }

--- a/TestFixtures/Code.lean
+++ b/TestFixtures/Code.lean
@@ -3,8 +3,12 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoSlides
-import Verso.Doc.Concrete
+
+module
+
+public import VersoSlides
+import Std.Tactic.BVDecide.Normalize.Prop
+meta import all Init.System.IO
 
 open VersoSlides
 

--- a/TestFixtures/DiagramAnim.lean
+++ b/TestFixtures/DiagramAnim.lean
@@ -3,9 +3,14 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoSlides
-import Verso.Doc.Concrete
-import Illuminate
+
+module
+
+public import VersoSlides
+import Illuminate -- shake: keep
+public meta import VersoSlides.Animate
+public meta import Illuminate.Animation.Effects
+public meta import Illuminate.Animation.Easing
 
 open VersoSlides
 

--- a/TestFixtures/Markup.lean
+++ b/TestFixtures/Markup.lean
@@ -3,8 +3,10 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoSlides
-import Verso.Doc.Concrete
+
+module
+
+public import VersoSlides
 
 open VersoSlides
 

--- a/TestFixtures/MinimalThemed.lean
+++ b/TestFixtures/MinimalThemed.lean
@@ -3,8 +3,10 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoSlides
-import Verso.Doc.Concrete
+
+module
+
+public import VersoSlides
 
 open VersoSlides
 

--- a/TestFixtures/PanelOption.lean
+++ b/TestFixtures/PanelOption.lean
@@ -3,8 +3,10 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoSlides
-import Verso.Doc.Concrete
+
+module
+
+public import VersoSlides
 
 open VersoSlides
 

--- a/TestFixtures/Theme.lean
+++ b/TestFixtures/Theme.lean
@@ -3,8 +3,10 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoSlides
-import Verso.Doc.Concrete
+
+module
+
+public import VersoSlides
 
 open VersoSlides
 

--- a/TestMain.lean
+++ b/TestMain.lean
@@ -3,6 +3,9 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+
+module
+
 import VersoSlides
 import TestElab
 
@@ -16,7 +19,7 @@ def runCmd (cmd : String) (args : Array String) (desc : String) : IO UInt32 := d
     IO.eprintln s!"[test] {desc} failed (exit code {result.exitCode})"
   return result.exitCode
 
-def main (args : List String) : IO UInt32 := do
+public def main (args : List String) : IO UInt32 := do
   let mut runPlaywright := true
   for arg in args do
     match arg with

--- a/Tests.lean
+++ b/Tests.lean
@@ -3,6 +3,12 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Tests.Fragmentize
-import Tests.Render
-import Tests.CommentParsers
+
+module
+
+/-
+The individual test modules are executable roots, so each must export a
+declaration named `main`. Importing more than one of them into a module-system
+file would cause those declarations to collide; Lake's executable targets in
+`lakefile.lean` build them independently instead.
+-/

--- a/Tests/CommentParsers.lean
+++ b/Tests/CommentParsers.lean
@@ -6,6 +6,8 @@ Author: David Thrane Christiansen
 /-
   Tests for the magic comment parsers.
 -/
+module
+
 import VersoSlides.SlideCode.CommentParsers
 
 open VersoSlides
@@ -58,7 +60,7 @@ def testBool (name : String) (actual expected : Bool) : TestM Unit := do
     }
 
 
-def main : IO UInt32 := do
+public def main : IO UInt32 := do
   let ((), s) ← tests.run {}
   s.report
 where

--- a/Tests/ConfigValidation.lean
+++ b/Tests/ConfigValidation.lean
@@ -3,6 +3,9 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+
+module
+
 import VersoSlides
 
 open VersoSlides
@@ -54,7 +57,7 @@ def expectFailMentioning (desc : String) (cfg : Config)
     else
       return .error s!"{desc}: error missing substrings {missing}\n  got: {msg}"
 
-def main : IO UInt32 := do
+public def main : IO UInt32 := do
   let cases : List (IO (Except String Unit)) := [
     expectOk "builtin theme + no extraCss" { theme := "black" },
     expectOk "builtin theme + unique extraCss"

--- a/Tests/Fragmentize.lean
+++ b/Tests/Fragmentize.lean
@@ -6,6 +6,8 @@ Author: David Thrane Christiansen
 /-
   Tests for the `fragmentize` transformation.
 -/
+module
+
 import SubVerso.Highlighting.Highlighted
 import VersoSlides.SlideCode
 
@@ -96,7 +98,7 @@ def testErr (name : String) (input : Highlighted) : TestM Unit := do
     }
 
 
-def main : IO UInt32 := do
+public def main : IO UInt32 := do
   let ((), s) ← tests.run {}
   s.report
 where

--- a/Tests/Render.lean
+++ b/Tests/Render.lean
@@ -6,6 +6,8 @@ Author: David Thrane Christiansen
 /-
   Tests for rendering-related HTML output.
 -/
+module
+
 import SubVerso.Highlighting.Highlighted
 import VersoSlides.Render
 import VersoSlides.SlideCode
@@ -99,7 +101,7 @@ def testHtmlHas (name : String) (html needle : String) : TestM Unit := do
     }
 
 
-def main : IO UInt32 := do
+public def main : IO UInt32 := do
   let ((), s) ← tests.run {}
   s.report
 where

--- a/VersoSlides.lean
+++ b/VersoSlides.lean
@@ -4,18 +4,20 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 -- This module serves as the root of the `VersoSlides` library.
-import VersoSlides.Basic
-import VersoSlides.Attributes
-import VersoSlidesVendored
-import VersoSlides.Render
-import VersoSlides.Directives
-import VersoSlides.ImageWidget
-import VersoSlides.OtherLanguages
-import VersoSlides.InlineLean
-import VersoSlides.Diagram
-import VersoSlides.Animate
-import VersoSlides.SlideCode
-import VersoSlides.SlideCode.Export
-import VersoSlides.SlideCode.Render
-import VersoSlides.ModuleExample
-import VersoSlides.LibModule
+module
+
+public import VersoSlides.Basic
+public import VersoSlides.Attributes
+public import VersoSlides.Render
+public import VersoSlides.Directives
+public meta import VersoSlides.Directives
+public import VersoSlides.ImageWidget
+public import VersoSlides.OtherLanguages
+public import VersoSlides.InlineLean
+public import VersoSlides.Diagram
+public import VersoSlides.Animate
+public import VersoSlides.SlideCode
+public import VersoSlides.SlideCode.Export
+public import VersoSlides.SlideCode.Render
+public import VersoSlides.ModuleExample
+public import VersoSlides.LibModule

--- a/VersoSlides/Animate.lean
+++ b/VersoSlides/Animate.lean
@@ -4,12 +4,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import VersoSlides.Basic
+module
+
+meta import VersoSlides.Basic -- shake: keep
 import VersoSlides.Diagram
-import Verso.Doc.ArgParse
-import Verso.Doc.Elab.Monad
-import VersoManual.InlineLean
-import Illuminate
+public meta import VersoSlides.Diagram
+public import Verso.Doc.Elab.Monad
+import Illuminate.Animation.Widget
+public import Illuminate.Animation.Types
+public import Illuminate.Backend.SVG
+meta import VersoManual.InlineLean.Scopes
+meta import Verso.WithoutAsync
 
 open Verso ArgParse Doc Elab
 open Lean Elab
@@ -19,6 +24,8 @@ open Verso (withoutAsync)
 open Lean.Doc.Syntax
 
 namespace VersoSlides
+
+public section
 
 /-- A step in a slide animation. Extends {name}`Illuminate.Step` with an optional
     `reveal.js` fragment index for interleaving with other slide fragments. -/
@@ -52,7 +59,7 @@ def SlideAnimation.compile (sa : SlideAnimation) (fps : Nat := 60) : CompiledSli
     (sa.steps.filterMap fun s =>
       if s.pause then some s.fragmentIndex else none).toArray
 
-private structure AnimateConfig where
+structure AnimateConfig where
   fps : Nat := 60
   background : Option String := none
   autoplay : Bool := false
@@ -60,14 +67,14 @@ private structure AnimateConfig where
 section
 variable [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m]
 
-private def AnimateConfig.parse : ArgParse m AnimateConfig :=
+private meta def AnimateConfig.parse : ArgParse m AnimateConfig :=
   AnimateConfig.mk <$> .namedD `fps .nat 60 <*> .named `background .string true <*> .flag `autoplay false
 
-instance : FromArgs AnimateConfig m where
-  fromArgs := AnimateConfig.parse
+meta instance : FromArgs AnimateConfig m where
+  fromArgs := private AnimateConfig.parse
 end
 
-private initialize animContainerCounter : IO.Ref Nat ← IO.mkRef 0
+private meta initialize animContainerCounter : IO.Ref Nat ← IO.mkRef 0
 
 open Lean.Widget Lean.Elab.Term Lean.Meta Illuminate in
 private meta unsafe def animateExpanderUnsafe (config : AnimateConfig) (str : StrLit) :
@@ -135,10 +142,12 @@ private meta unsafe def animateExpanderUnsafe (config : AnimateConfig) (str : St
 
 open Lean.Widget Lean.Elab.Term Lean.Meta Illuminate in
 @[implemented_by animateExpanderUnsafe]
-private opaque animateExpanderImpl (config : AnimateConfig) (str : StrLit) : DocElabM Term
+private meta opaque animateExpanderImpl (config : AnimateConfig) (str : StrLit) : DocElabM Term
 
 @[code_block]
-def «animate» : CodeBlockExpanderOf AnimateConfig
+meta def «animate» : CodeBlockExpanderOf AnimateConfig
   | config, str => animateExpanderImpl config str
+
+end
 
 end VersoSlides

--- a/VersoSlides/Basic.lean
+++ b/VersoSlides/Basic.lean
@@ -3,13 +3,13 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-module
+module -- shake: keep-all
 public import Verso.Doc
 public import Verso.Output.Html
 public import VersoSlides.ImgSrc
+-- `CssFile` is part of this module's public API.
 public import VersoManual.Html.CssFile
 public import VersoSlidesVendored
-import Std.Data.HashMap
 
 open Lean
 open Verso Output

--- a/VersoSlides/Diagram.lean
+++ b/VersoSlides/Diagram.lean
@@ -4,11 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import VersoSlides.Basic
-import Verso.Doc.ArgParse
-import Verso.Doc.Elab.Monad
-import VersoManual.InlineLean
-import Illuminate
+module
+
+meta import VersoSlides.Basic -- shake: keep
+public import Verso.Doc.Elab.Monad
+import Illuminate.Widget
+meta import Illuminate.Widget
+meta import VersoManual.InlineLean.Scopes
+meta import Verso.WithoutAsync
+public meta import Verso.Doc.Elab.Monad
 
 open Verso ArgParse Doc Elab
 open Lean Elab
@@ -19,22 +23,24 @@ open Lean.Doc.Syntax
 
 namespace VersoSlides
 
-private structure DiagramConfig where
+public section
+
+structure DiagramConfig where
   background : Option String := none
 
 section
 variable [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m]
 
-private def DiagramConfig.parse : ArgParse m DiagramConfig :=
+private meta def DiagramConfig.parse : ArgParse m DiagramConfig :=
   DiagramConfig.mk <$> .named `background .string true
 
-instance : FromArgs DiagramConfig m where
-  fromArgs := DiagramConfig.parse
+meta instance : FromArgs DiagramConfig m where
+  fromArgs := private DiagramConfig.parse
 end
 
 /-- Extracts the `viewBox` width from an SVG string produced by Illuminate.
     The viewBox format is `"minX minY width height"`. -/
-def svgViewBoxWidth (svg : String) : Float :=
+meta def svgViewBoxWidth (svg : String) : Float :=
   let go : Option Float := do
     let parts := (svg.splitOn "viewBox=\"").toArray
     if h : parts.size > 1 then
@@ -111,10 +117,12 @@ private meta unsafe def diagramExpanderUnsafe (config : DiagramConfig) (str : St
 
 open Lean.Widget Lean.Elab.Term Lean.Meta Illuminate in
 @[implemented_by diagramExpanderUnsafe]
-private opaque diagramExpanderImpl (config : DiagramConfig) (str : StrLit) : DocElabM Term
+private meta opaque diagramExpanderImpl (config : DiagramConfig) (str : StrLit) : DocElabM Term
 
 @[code_block]
-def diagram : CodeBlockExpanderOf DiagramConfig
+meta def diagram : CodeBlockExpanderOf DiagramConfig
   | config, str => diagramExpanderImpl config str
+
+end
 
 end VersoSlides

--- a/VersoSlides/Directives.lean
+++ b/VersoSlides/Directives.lean
@@ -4,22 +4,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 module
-import VersoSlides.Basic
 public meta import VersoSlides.Basic
-import VersoSlides.ImageWidget
 public meta import VersoSlides.ImageWidget
-public meta import VersoSlides.ImgSrc
-import Verso.Doc.Elab
-import Verso.Doc.ArgParse
-public import Verso.Doc.Elab.Monad
-public meta import Verso.Doc.Elab.Block
-public meta import Verso.Doc.Elab.Inline
+import VersoSlides.ImgSrc
+public import Verso.Doc.Elab
+public meta import Verso.Doc.Elab
 
 open Verso Doc Elab ArgParse
 open Lean Elab Widget
 open Lean.Doc.Syntax
 
-register_option verso.slides.warnOnImage : Bool := {
+public register_option verso.slides.warnOnImage : Bool := {
   defValue := true
   descr := "if true, warn when Markdown image syntax ![alt](url) is used instead of the {image} role"
 }
@@ -447,6 +442,8 @@ public meta def image : RoleExpanderOf ImageArgs
 
   ``(Inline.other (VersoSlides.InlineExt.image $(quote imgSrc) $(quote alt) $(quote args.width) $(quote args.height) $(quote args.class)) #[])
 
+attribute [-inline_expander] Lean.Doc.Syntax.image.expand
+
 /--
 Intercepts the Markdown-like `![alt](url)` syntax and warns that the `{image}` role should be used
 instead, since it supports width, height, and class, and uses local path resolution. Controlled by
@@ -454,7 +451,7 @@ the `verso.slides.warnOnImage` option. After warning, delegates to the default h
 -/
 @[inline_expander Lean.Doc.Syntax.image]
 public meta def warnOnMarkdownImage : InlineExpander
-  | `(inline| image( $alt:str ) ( $url )) => do
+  | stx@`(inline| image( $alt:str ) ( $url )) => do
     if (← getOptions).getBool `verso.slides.warnOnImage true then
       let suggestion := "{image " ++ url.getString.quote ++ "}[" ++ alt.getString ++ "]"
       let msg := m!"This image syntax is missing features that are useful for slides, such as width and height."
@@ -463,7 +460,7 @@ public meta def warnOnMarkdownImage : InlineExpander
          m!"It supports width, height, and CSS class, and it copies images to the output directory.").hint
         #[{ suggestion := .string suggestion }]
       logWarningAt alt (msg ++ h)
-    throwUnsupportedSyntax
+    Lean.Doc.Syntax.image.expand stx
   | _ => throwUnsupportedSyntax
 
 /-- Arguments for the `:::table` directive. All features are off by default. -/

--- a/VersoSlides/ImageWidget.lean
+++ b/VersoSlides/ImageWidget.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 module
-import Lean.Widget
+import Lean.Widget.UserWidget
+public meta import Lean.Widget.UserWidget
 public import Lean.CoreM
 set_option doc.verso true
 

--- a/VersoSlides/InlineLean.lean
+++ b/VersoSlides/InlineLean.lean
@@ -4,11 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import VersoSlides.Basic
-import VersoSlides.SlideCode.Export
-import VersoManual.InlineLean
-import Verso.Code.Highlighted
-import Verso.Doc.Helpers
+module
+
+meta import VersoSlides.Basic -- shake: keep
+public meta import VersoSlides.SlideCode.Export
+public import VersoManual.InlineLean
+public meta import VersoManual.InlineLean
 
 open Lean Elab
 open Verso Doc Elab
@@ -20,12 +21,14 @@ open Verso.Genre.Manual.InlineLean.Scopes (getScopes setScopes runWithOpenDecls 
 open Verso (withoutAsync)
 open Lean.Doc.Syntax
 
-register_option verso.slides.panel : Bool := {
+public register_option verso.slides.panel : Bool := {
   defValue := true
   descr := "default value for the `panel` flag on Lean code boxes, which determines whether to show the interactive info panel"
 }
 
 namespace VersoSlides
+
+public section
 
 /--
 An `ArgParse` parser for the `panel` flag shared by all code-box directives. Its default is taken
@@ -33,12 +36,12 @@ from the `verso.slides.panel` option (which itself defaults to `true`), so a doc
 default with `set_option verso.slides.panel false` while individual boxes still override it with
 `+panel`/`-panel`.
 -/
-def panelFlag [Monad m] [MonadOptions m] : Verso.ArgParse m Bool :=
+meta def panelFlag [Monad m] [MonadOptions m] : Verso.ArgParse m Bool :=
   .flagM `panel (return (← getOptions).getBool `verso.slides.panel true)
     (doc? := "whether to show the interactive info panel below the code box (defaults to the value of the `verso.slides.panel` option)")
 
 /-- Syntax node kinds whose output should be rendered inline after the command. -/
-private def queryCommandKinds : Array SyntaxNodeKind :=
+private meta def queryCommandKinds : Array SyntaxNodeKind :=
   open Lean.Parser.Command in
   #[``eval, ``check, ``print, ``reduceCmd]
 
@@ -46,14 +49,14 @@ private def queryCommandKinds : Array SyntaxNodeKind :=
 Returns `true` if `stx` contains a query command (e.g. `#eval`, `#check`)
 anywhere in its syntax tree, accounting for wrappers like `open ... in`.
 -/
-private def isQueryCommand (stx : Syntax) : Bool :=
+private meta def isQueryCommand (stx : Syntax) : Bool :=
   (stx.find? (queryCommandKinds.contains ·.getKind)).isSome
 
 /-- Token strings for query commands (used to find them in `Highlighted` trees). -/
-private def queryCommandTokens : Array String := #["#check", "#eval", "#print", "#reduce"]
+private meta def queryCommandTokens : Array String := #["#check", "#eval", "#print", "#reduce"]
 
 /-- Returns `true` if `hl` contains a query command keyword token anywhere in its tree. -/
-private partial def containsQueryToken : Highlighted → Bool
+private meta partial def containsQueryToken : Highlighted → Bool
   | .token tok => tok.kind matches .keyword .. && queryCommandTokens.contains tok.content
   | .seq xs => xs.any containsQueryToken
   | .span _ x | .tactics _ _ _ x => containsQueryToken x
@@ -64,7 +67,7 @@ For a query command's highlighted code, find spans that contain a query command
 token and collect their info-severity messages as `point` nodes to append.
 The original tree is left intact (spans keep their info for diagnostic markers).
 -/
-private partial def collectQueryOutput : Highlighted → Array Highlighted
+private meta partial def collectQueryOutput : Highlighted → Array Highlighted
   | .span info x =>
     if containsQueryToken x then
       info.filterMap fun (kind, msg) =>
@@ -79,19 +82,19 @@ private partial def collectQueryOutput : Highlighted → Array Highlighted
 Slides-specific code block configuration, extending {name}`LeanBlockConfig` with a panel toggle and
 a vertical-stretch toggle.
 -/
-private structure SlidesLeanBlockConfig extends LeanBlockConfig where
+structure SlidesLeanBlockConfig extends LeanBlockConfig where
   panel : Bool
   stretch : Bool
 
 open Verso ArgParse in
-instance : FromArgs SlidesLeanBlockConfig DocElabM where
+meta instance : FromArgs SlidesLeanBlockConfig DocElabM where
   fromArgs := SlidesLeanBlockConfig.mk <$>
     fromArgs <*>
     panelFlag <*>
     .flag `stretch true
 
 /-- Callback for `elabCommands`: produces a `Block.other (BlockExt.slideCode ...)` term. -/
-private def toSlidesHighlightedBlock (panel stretch shouldShow : Bool) (hls : Highlighted)
+private meta def toSlidesHighlightedBlock (panel stretch shouldShow : Bool) (hls : Highlighted)
     (str : StrLit) : DocElabM Term := do
   if !shouldShow then
     return ← ``(Verso.Doc.Block.concat #[])
@@ -110,7 +113,7 @@ private def toSlidesHighlightedBlock (panel stretch shouldShow : Bool) (hls : Hi
     throwErrorAt str.raw msg
 
 /-- Callback for `elabCommands`: produces an `Inline.other (InlineExt.slideCode ...)` term. -/
-private def toSlidesHighlightedInline (shouldShow : Bool) (hls : Highlighted) (str : StrLit) :
+private meta def toSlidesHighlightedInline (shouldShow : Bool) (hls : Highlighted) (str : StrLit) :
     DocElabM Term := do
   if !shouldShow then
     return ← ``(Verso.Doc.Inline.concat #[])
@@ -123,7 +126,7 @@ private def toSlidesHighlightedInline (shouldShow : Bool) (hls : Highlighted) (s
     throwErrorAt str.raw msg
 
 /-- Abbreviate a string to the first line, truncated to `width` characters. -/
-private def abbrevFirstLine (width : Nat) (str : String) : String :=
+private meta def abbrevFirstLine (width : Nat) (str : String) : String :=
   let str := str.trimAsciiStart
   let short := str.take width |>.replace "\n" "⏎"
   if short.toSlice == str then short else short ++ "…"
@@ -132,7 +135,7 @@ private def abbrevFirstLine (width : Nat) (str : String) : String :=
 Fork of `Verso.Genre.Manual.InlineLean.elabCommands` that passes `collectFormat := true`
 to `highlightIncludingUnparsed`, enabling format data collection for reflowable rendering.
 -/
-def elabCommandsWithFormat (config : LeanBlockConfig) (str : StrLit)
+meta def elabCommandsWithFormat (config : LeanBlockConfig) (str : StrLit)
     (toHighlightedLeanContent : (shouldShow : Bool) → (hls : Highlighted) → (str: StrLit) → DocElabM Term)
     (minCommands : Option Nat := none)
     (maxCommands : Option Nat := none) :
@@ -147,7 +150,10 @@ def elabCommandsWithFormat (config : LeanBlockConfig) (str : StrLit)
     let origScopes ← if config.fresh then pure [{header := ""}] else getScopes
 
     let origScopes := origScopes.modifyHead fun sc =>
-      { sc with opts := pp.tagAppFns.set (Elab.async.set sc.opts false) true }
+      let opts := pp.tagAppFns.set (Elab.async.set sc.opts false) true
+      -- Keep declarations from documented code in the public environment so their written names
+      -- remain usable by later slide examples under the module system.
+      { sc with opts, isPublic := true }
 
     let text ← getFileMap
     let (ictx, startPos) ← strLitInputContext str.raw (← getFileName)
@@ -261,12 +267,12 @@ where
 
 /-- Elaborated Lean code block for slides (with format data collection). -/
 @[code_block]
-def lean : CodeBlockExpanderOf SlidesLeanBlockConfig
+meta def lean : CodeBlockExpanderOf SlidesLeanBlockConfig
   | config, str => elabCommandsWithFormat config.toLeanBlockConfig str (toSlidesHighlightedBlock config.panel config.stretch)
 
 /-- Inline elaborated Lean command for slides (with format data collection). -/
 @[role]
-def leanCommand : RoleExpanderOf LeanBlockConfig
+meta def leanCommand : RoleExpanderOf LeanBlockConfig
   | config, inls => do
     if let some str ← oneCodeStr? inls then
       elabCommandsWithFormat config str toSlidesHighlightedInline (minCommands := some 1) (maxCommands := some 1)
@@ -275,7 +281,7 @@ def leanCommand : RoleExpanderOf LeanBlockConfig
 
 /-- Inline elaborated Lean term for slides (with format data collection). -/
 @[role lean]
-def leanInline : RoleExpanderOf LeanInlineConfig
+meta def leanInline : RoleExpanderOf LeanInlineConfig
   | config, inlines => withoutAsync do
     let #[arg] := inlines
       | throwError "Expected exactly one argument"
@@ -344,14 +350,14 @@ def leanInline : RoleExpanderOf LeanInlineConfig
     toSlidesHighlightedInline config.show hls term
 
 /-- Configuration for the `name` role. -/
-private structure NameConfig where
+structure NameConfig where
   full : Option Name
 
 section
 open Verso.ArgParse
 variable [Monad m] [MonadError m] [MonadLiftT CoreM m] [MonadLiftT TermElabM m]
 
-private def NameConfig.parse : ArgParse m NameConfig :=
+private meta def NameConfig.parse : ArgParse m NameConfig :=
   NameConfig.mk <$> ((fun _ => none) <$> .done <|> .positional `name ref)
 where
   ref : ValDesc m (Option Name) := {
@@ -368,11 +374,12 @@ where
       | other => throwError "Expected reference name, got {repr other}"
   }
 
-instance : FromArgs NameConfig m := ⟨NameConfig.parse⟩
+meta instance : FromArgs NameConfig m where
+  fromArgs := private NameConfig.parse
 end
 
 /-- Create a highlighted token for a resolved constant name. -/
-private def constTok [Monad m] [MonadEnv m] [MonadLiftT MetaM m] [MonadLiftT IO m]
+private meta def constTok [Monad m] [MonadEnv m] [MonadLiftT MetaM m] [MonadLiftT IO m]
     (resolvedName : Name) (str : String) :
     m Highlighted := do
   let docs ← findDocString? (← getEnv) resolvedName
@@ -387,7 +394,7 @@ with signature and docstring hover info.
 Usage: `{name}[List.map]` or `{name List.map'}[map']`
 -/
 @[role]
-def name : RoleExpanderOf NameConfig
+meta def name : RoleExpanderOf NameConfig
   | cfg, #[arg] => do
     let `(inline|code( $nameStx:str )) := arg
       | throwErrorAt arg "Expected code literal with the example name"
@@ -412,3 +419,7 @@ def name : RoleExpanderOf NameConfig
       throwErrorAt more[0] "Unexpected contents"
     else
       throwError "Unexpected arguments"
+
+end
+
+end VersoSlides

--- a/VersoSlides/LibModule.lean
+++ b/VersoSlides/LibModule.lean
@@ -4,23 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import Lean.Elab.Term
+module
 
-import Verso.Code.Highlighted
-import Verso.Code.External
-import Verso.Doc.Elab
-import Verso.Doc.ArgParse
-import Verso.Doc.Helpers
-import Verso.ExpectString
-import Verso.Log
-import SubVerso.Highlighting.Code
-import SubVerso.Module
-
-import VersoSlides.Basic
-import VersoSlides.InlineLean
-import VersoSlides.ModuleExample
+meta import VersoSlides.Basic -- shake: keep
+public import VersoSlides.ModuleExample
 import VersoSlides.SlideCode
-import VersoSlides.SlideCode.Export
+public meta import VersoSlides.ModuleExample
+public meta import Std.Data.Iterators.Combinators.Drop
 
 open Verso.Doc.Elab
 open Verso.ArgParse
@@ -31,6 +21,8 @@ open SubVerso.Highlighting
 open SubVerso.Module
 
 namespace VersoSlides
+
+public section
 
 /-- Arguments accepted by `leanLibCode`. -/
 structure LibModuleConfig where
@@ -56,7 +48,7 @@ section
 
 variable [Monad m] [MonadError m] [MonadOptions m]
 
-instance : FromArgs LibModuleConfig m where
+meta instance : FromArgs LibModuleConfig m where
   fromArgs :=
     LibModuleConfig.mk
       <$> .positional `module .ident
@@ -69,7 +61,7 @@ instance : FromArgs LibModuleConfig m where
 end
 
 /-- Cached extracted module JSON, keyed by fully-qualified module name. -/
-private structure LoadedLibModule where
+private meta structure LoadedLibModule where
   /-- Hash of the JSON file's bytes at load time. -/
   fileHash : UInt64
   items : Array ModuleItem
@@ -79,7 +71,7 @@ Environment extension holding parsed external-library modules for the current Le
 module name; invalidated across sessions when the env resets, and invalidated within a session by a
 file-hash check in `loadLibModule`.
 -/
-private initialize loadedLibModulesExt :
+private meta initialize loadedLibModulesExt :
     EnvExtension (Std.HashMap Name LoadedLibModule) ←
   registerEnvExtension (pure {})
 
@@ -91,7 +83,7 @@ elaboration.
 If `package?` is given, targets the module within that package (`@pkg/+mod:highlighted`); otherwise
 queries across the workspace (`+mod:highlighted`).
 -/
-private def queryFacetBytes (modName : Name) (package? : Option Name) :
+private meta def queryFacetBytes (modName : Name) (package? : Option Name) :
     IO (Option ByteArray) := do
   let tgt :=
     match package? with
@@ -115,7 +107,7 @@ auto-deleted by `withTempFile`.
 doesn't include the toolchain's `src/lean` directory. `LEAN_SRC_PATH` is overridden with the
 toolchain sysroot (via `Lean.findSysroot`) so prelude and stdlib modules are reachable.
 -/
-private def fallbackExtractBytes (modName : Name) : IO (Option ByteArray) := do
+private meta def fallbackExtractBytes (modName : Name) : IO (Option ByteArray) := do
   let exeOut ← IO.Process.output {
     cmd := "lake",
     args := #["query", "--text", "subverso-extract-mod"]
@@ -136,7 +128,7 @@ private def fallbackExtractBytes (modName : Name) : IO (Option ByteArray) := do
     some <$> IO.FS.readBinFile jsonFile
 
 /-- Diagnostic-friendly guidance when neither the facet nor the fallback can find the module. -/
-private def noModuleError (modName : Name) (package? : Option Name) : MessageData :=
+private meta def noModuleError (modName : Name) (package? : Option Name) : MessageData :=
   let qual :=
     match package? with
     | some p => s!"@{p}/+{modName}:highlighted"
@@ -157,7 +149,7 @@ Loads the parsed `ModuleItem`s for `modName`, hitting the env-extension cache wh
 cache has a stale entry (file hash changed mid-session), asks the user to restart rather than
 silently handing out a mix of old and new data.
 -/
-private def loadLibModule [Monad m] [MonadEnv m] [MonadError m] [MonadLiftT IO m]
+private meta def loadLibModule [Monad m] [MonadEnv m] [MonadError m] [MonadLiftT IO m]
     (modName : Name) (package? : Option Name) (blame : Syntax) : m (Array ModuleItem) := do
   let bytes ←
     match ← (queryFacetBytes modName package? : IO _) with
@@ -183,14 +175,14 @@ private def loadLibModule [Monad m] [MonadEnv m] [MonadError m] [MonadLiftT IO m
     m.insert modName { fileHash := currentHash, items := mod.items }
   return mod.items
 
-private inductive Ctx where
+private meta inductive Ctx where
   | tactics (goals : Array (Highlighted.Goal Highlighted)) (s e : Nat)
   | span (info : Array (Highlighted.Span.Kind × Highlighted.MessageContents Highlighted))
 
 /--
 Gets the indicated line range, on the assumption that the code in question starts at line `line`.
 -/
-def getLines (line : Nat) (startLine endLine : Nat) (hl : Highlighted) : Highlighted := Id.run do
+meta def getLines (line : Nat) (startLine endLine : Nat) (hl : Highlighted) : Highlighted := Id.run do
   let mut line := line
   let mut ctx : List (Highlighted × Ctx × List Highlighted) := []
   let mut doc : List Highlighted := [hl]
@@ -254,7 +246,7 @@ or `none` if the item lies entirely outside the range. Items entirely inside
 the range pass through without traversal; only items straddling a boundary
 are walked.
 -/
-private def sliceItem (sl el : Nat) (item : ModuleItem) : Option Highlighted := do
+private meta def sliceItem (sl el : Nat) (item : ModuleItem) : Option Highlighted := do
   let (s, e) ← item.range
   if e.line < sl ∨ s.line > el then none
   else if sl ≤ s.line ∧ e.line ≤ el then some item.code
@@ -273,7 +265,7 @@ enough — concretely, when the Levenshtein distance exceeds
 The returned text contains complete source lines, snapped at both ends and suitable for use directly
 as the body of a quickfix replacement.
 -/
-def findBodyLineRange (body : String) (items : Array ModuleItem) :
+meta def findBodyLineRange (body : String) (items : Array ModuleItem) :
     Option (Nat × Nat × String) := Id.run do
   if body.isEmpty then return none
   let modText : String := items.foldl (init := "") fun s i => s ++ i.code.toString
@@ -339,7 +331,7 @@ def findBodyLineRange (body : String) (items : Array ModuleItem) :
 Picks the highlighted code to include based on the user's config (decl, line range, or all). For
 line ranges, slices each overlapping item to the requested lines via `sliceItem`.
 -/
-private def selectCode (items : Array ModuleItem) (cfg : LibModuleConfig)
+private meta def selectCode (items : Array ModuleItem) (cfg : LibModuleConfig)
     : Except String Highlighted := do
   match cfg.decl, cfg.startLine, cfg.endLine with
   | some _, some _, _ | some _, _, some _ =>
@@ -454,7 +446,7 @@ def bar : Nat := 42
 ```
 -/
 @[code_block]
-def leanLibCode : CodeBlockExpanderOf LibModuleConfig
+meta def leanLibCode : CodeBlockExpanderOf LibModuleConfig
   | cfg, str => do
     let modName := cfg.«module».getId
     let pkgName? := cfg.«package».map (·.getId)
@@ -507,3 +499,7 @@ def leanLibCode : CodeBlockExpanderOf LibModuleConfig
            #[Verso.Doc.Block.code $(quote str.getString)])
     | .error msg =>
       throwErrorAt str.raw msg
+
+end
+
+end VersoSlides

--- a/VersoSlides/ModuleExample.lean
+++ b/VersoSlides/ModuleExample.lean
@@ -4,23 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import Lean.Elab.Term
-import Lean.Elab.Tactic
+module
 
-import Verso.Code.Highlighted
-import Verso.Doc.Elab
-import Verso.Doc.ArgParse
-import Verso.Doc.Suggestion
-import Verso.Doc.Helpers
-import Verso.Log
-import SubVerso.Highlighting.Code
-
-
-import VersoSlides.Basic
-import VersoSlides.InlineLean
+meta import VersoSlides.Basic -- shake: keep
+public import VersoSlides.InlineLean
 import VersoSlides.SlideCode
-import VersoSlides.SlideCode.Export
-import SubVerso.Module
+public meta import VersoSlides.InlineLean
 
 open Verso.Doc.Elab
 open Verso.ArgParse
@@ -29,10 +18,12 @@ open Lean
 
 namespace VersoSlides
 
+public section
+
 /-- Environment variables that should be cleared when running Lake/Lean subprocesses.
 Prevents the parent's build environment from leaking into child processes, which
 can cause spurious rebuilds (especially via `LEAN_GITHASH`). -/
-private def lakeEnvBlacklist : Array (String × Option String) :=
+private meta def lakeEnvBlacklist : Array (String × Option String) :=
   #["LAKE", "LAKE_HOME", "LAKE_PKG_URL_MAP",
     "LEAN_SYSROOT", "LEAN_AR", "LEAN_PATH", "LEAN_SRC_PATH",
     "LEAN_GITHASH",
@@ -51,7 +42,7 @@ section
 
 variable [Monad m] [MonadError m] [MonadOptions m]
 
-instance : FromArgs ModuleConfig m where
+meta instance : FromArgs ModuleConfig m where
   fromArgs := ModuleConfig.mk <$>
     .named' `name true <*>
     .named' `moduleName true <*>
@@ -65,7 +56,7 @@ end
 
 section
 open SubVerso.Highlighting
-partial def getMessages (hl : Highlighted) : Array (Nat × Highlighted.Message) :=
+meta partial def getMessages (hl : Highlighted) : Array (Nat × Highlighted.Message) :=
   let ((), _, out) := go hl (0, #[])
   out
 where
@@ -82,7 +73,7 @@ where
     | .point sev contents =>
       modify fun (l, msgs) => (l, msgs.push (l, ⟨sev, contents⟩))
 
-def dropBlanks (hl : Highlighted) : Highlighted :=
+meta def dropBlanks (hl : Highlighted) : Highlighted :=
   match hl with
   | .text s => .text s.trimAsciiStart.copy
   | .seq xs => Id.run do
@@ -95,7 +86,7 @@ def dropBlanks (hl : Highlighted) : Highlighted :=
 
 end
 
-def logBuild [Monad m] [MonadRef m] [MonadOptions m] [MonadLog m] [AddMessageContext m] (command : String) (out : IO.Process.Output) (blame : Option Syntax := none) : m Unit := do
+meta def logBuild [Monad m] [MonadRef m] [MonadOptions m] [MonadLog m] [AddMessageContext m] (command : String) (out : IO.Process.Output) (blame : Option Syntax := none) : m Unit := do
   let blame ←
     if let some b := blame then pure b else getRef
   let mut buildOut : Array MessageData := #[]
@@ -106,7 +97,7 @@ def logBuild [Monad m] [MonadRef m] [MonadOptions m] [MonadLog m] [AddMessageCon
   unless buildOut.isEmpty do
     logSilentInfoAt blame <| .trace {cls := `build} m!"{command}" buildOut
 
-def lineStx [Monad m] [MonadFileMap m] (l : Nat) : m Syntax := do
+meta def lineStx [Monad m] [MonadFileMap m] (l : Nat) : m Syntax := do
   let text ← getFileMap
   -- 0-indexed vs 1-indexed requires +1 and +2 here
   let r := ⟨text.lineStart (l + 1), text.lineStart (l + 2)⟩
@@ -114,7 +105,7 @@ def lineStx [Monad m] [MonadFileMap m] (l : Nat) : m Syntax := do
 
 open Lean.Doc.Syntax in
 @[code_block]
-def leanModule : CodeBlockExpanderOf ModuleConfig
+meta def leanModule : CodeBlockExpanderOf ModuleConfig
   | { name, moduleName, error, «show», panel, stretch, lakefile }, str => do
     let line := (← getFileMap).utf8PosToLspPos str.raw.getPos! |>.line
     let leanCode := line.fold (fun _ _ s => s.push '\n') "" ++ str.getString ++ "\n"
@@ -226,16 +217,16 @@ structure IdentRefConfig where
 
 section
 variable [Monad m] [MonadError m]
-instance : FromArgs IdentRefConfig m where
+meta instance : FromArgs IdentRefConfig m where
   fromArgs := IdentRefConfig.mk <$> .positional' `name
 end
 
 @[code_block]
-def identRef : CodeBlockExpanderOf IdentRefConfig
+meta def identRef : CodeBlockExpanderOf IdentRefConfig
   | { name := x }, _ => pure x
 
 @[role identRef]
-def identRefRole : RoleExpanderOf IdentRefConfig
+meta def identRefRole : RoleExpanderOf IdentRefConfig
   | { name := x }, _ => pure x
 
 structure ModulesConfig where
@@ -245,12 +236,12 @@ structure ModulesConfig where
 
 section
 variable [Monad m] [MonadError m]
-instance : FromArgs ModulesConfig m where
+meta instance : FromArgs ModulesConfig m where
   fromArgs := ModulesConfig.mk <$> .flag `server true <*> .many (.named' `moduleRoot false) <*> .flag `error false
 end
 
 open Lean.Doc.Syntax in
-partial def getBlocks (block : Syntax) : StateT (NameMap (ModuleConfig × StrLit × Syntax)) DocElabM Syntax := do
+meta partial def getBlocks (block : Syntax) : StateT (NameMap (ModuleConfig × StrLit × Syntax)) DocElabM Syntax := do
   if block.getKind == ``Lean.Doc.Syntax.codeblock then
     if let `(Lean.Doc.Syntax.codeblock|```$x:ident $args* | $s:str ```) := block then
       try
@@ -274,7 +265,7 @@ partial def getBlocks (block : Syntax) : StateT (NameMap (ModuleConfig × StrLit
 
 open Lean.Doc.Syntax in
 open Verso.Doc (oneCodeStr?) in
-partial def getQuotes (stx : Syntax) : StateT (NameMap StrLit) DocElabM Syntax := do
+meta partial def getQuotes (stx : Syntax) : StateT (NameMap StrLit) DocElabM Syntax := do
   if stx.getKind == ``Lean.Doc.Syntax.role then
     if let `(Lean.Doc.Syntax.role|role{$x:ident $args*}[$inls*]) := stx then
       try
@@ -298,7 +289,7 @@ partial def getQuotes (stx : Syntax) : StateT (NameMap StrLit) DocElabM Syntax :
   | _ => return stx
 
 
-def getRoot (mods : NameMap (ModuleConfig × α)) : Option Name :=
+meta def getRoot (mods : NameMap (ModuleConfig × α)) : Option Name :=
   mods.foldl (init := none) fun
     | none, _, ({ moduleName, .. }, _) => moduleName.map (·.getId)
     | some y, _, ({moduleName := some x, ..}, _) => prefix? y x.getId
@@ -311,7 +302,7 @@ where
 
 open SubVerso.Highlighting in
 @[directive]
-def leanModules : DirectiveExpanderOf ModulesConfig
+meta def leanModules : DirectiveExpanderOf ModulesConfig
   | { server, moduleRoots, error }, blocks => do
     let (blocks, codeBlocks) ← blocks.mapM getBlocks {}
     let moduleRoots ←
@@ -498,3 +489,7 @@ where
   mkImports (root : Name) (mods : Array Name) : String :=
     "module\n" ++
     String.join (mods |>.filter (root.isPrefixOf ·) |>.toList |>.map (s!"import {·}\n"))
+
+end
+
+end VersoSlides

--- a/VersoSlides/OtherLanguages.lean
+++ b/VersoSlides/OtherLanguages.lean
@@ -4,8 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import VersoSlides.Basic
-import Verso.Doc.Elab.Monad
+module
+
+meta import VersoSlides.Basic -- shake: keep
+public import Verso.Doc.Elab.Monad
+public meta import Verso.Doc.Elab.Monad
 
 /-!
 Code block handler for other (non-Lean) languages.
@@ -35,8 +38,10 @@ open Lean.Doc.Syntax
 
 namespace VersoSlides
 
+public section
+
 /-- A language name parsed from either an identifier or a string literal. -/
-private def langName : Verso.ArgParse.ValDesc DocElabM String where
+private meta def langName : Verso.ArgParse.ValDesc DocElabM String where
   description := "a language name"
   signature := { ident := true, string := true, num := false }
   get
@@ -45,18 +50,20 @@ private def langName : Verso.ArgParse.ValDesc DocElabM String where
     | other => throwError "Expected language name (identifier or string), got {repr other}"
 
 /-- Configuration for the `code` block expander: a required language name. -/
-private structure CodeConfig where
+structure CodeConfig where
   language : String
 
-instance : Verso.ArgParse.FromArgs CodeConfig DocElabM where
-  fromArgs := CodeConfig.mk <$> .positional `language langName
+meta instance : Verso.ArgParse.FromArgs CodeConfig DocElabM where
+  fromArgs := private (CodeConfig.mk <$> .positional `language langName)
 
 /--
 Uses `reveal.js`'s built-in syntax highlighting for code.
 -/
 @[code_block]
-def code : CodeBlockExpanderOf CodeConfig
+meta def code : CodeBlockExpanderOf CodeConfig
   | config, str =>
     ``(Verso.Doc.Block.other (BlockExt.otherLanguage $(quote config.language) $(quote str.getString)) #[])
+
+end
 
 end VersoSlides

--- a/VersoSlides/Render.lean
+++ b/VersoSlides/Render.lean
@@ -3,14 +3,12 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoSlides.Basic
-import VersoSlides.Attributes
-import VersoSlides.SlideCode.Render
-import VersoSlides.SlideCode.Export
-import VersoSlidesVendored
-import Verso.Doc.Html
-import Verso.Output.Html
-import Verso.Code.Highlighted
+module
+
+public import VersoSlides.Attributes
+public import VersoSlides.SlideCode.Render
+public import VersoSlides.SlideCode.Export
+public import Verso.Doc.Html
 import Verso.Code.Highlighted.WebAssets
 import Illuminate.Animation.Render
 
@@ -26,6 +24,8 @@ HTML generation for {lit}`reveal.js` slides
 -/
 
 namespace VersoSlides
+
+public section
 
 /-- Pushes a CSS class onto all top-level HTML tags in a fragment. -/
 partial def addClassToHtml (cls : String) : Html → Html
@@ -79,7 +79,7 @@ def fragmentClass (style : Option String) : String :=
 
 
 /-- Conditionally wraps a code block in the interactive info panel layout. -/
-private def wrapWithPanel (codeHtml : Html) (panel : Bool) : Html :=
+def wrapWithPanel (codeHtml : Html) (panel : Bool) : Html :=
   if panel then
     {{ <div class="code-with-panel">
          {{codeHtml}}
@@ -597,7 +597,7 @@ stylesheet or an {lit}`extraCss` entry). Entries tagged {lit}`.binary` come
 from a {name}`ThemeAsset`. The distinction matters because two payloads at
 the same filename are only compatible if they share both tag and contents.
 -/
-private inductive AssetPayload
+inductive AssetPayload
   | text (body : String)
   | binary (bytes : ByteArray)
 
@@ -724,5 +724,7 @@ def slidesMain (config : Config := {}) (doc : Part Slides) : IO UInt32 := runWit
       writeBinFileWithDirs (imagesDir / outputName) contents
 
   IO.println s!"Slides written to {indexPath}"
+
+end
 
 end VersoSlides

--- a/VersoSlides/SlideCode/Render.lean
+++ b/VersoSlides/SlideCode/Render.lean
@@ -3,10 +3,11 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-module
+module -- shake: keep-all
 public import VersoSlides.SlideCode
 public import Verso.Code.Highlighted
-import Verso.Output.Html
+-- This module constructs `Html` directly.
+public import Verso.Output.Html
 
 set_option doc.verso true
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -11,6 +11,7 @@ require verso from git "https://github.com/leanprover/verso.git"@"main"
 
 package «verso-slides» where
   version := v!"0.1.0"
+  requiresModuleSystem := true
 
 input_dir vendorAssets where
   path := "vendor"


### PR DESCRIPTION
> **Closed — opened prematurely.** This PR was created by an automated coding session without explicit authorization to publish the work. Apologies for the noise; this implementation is not being proposed for review at this time.

## Work-in-progress context

This experimental change evaluates converting Verso Slides to Lean's module system. It:

- converts the library, demos, fixtures, and test executables to module-system syntax
- makes public and meta-phase dependencies explicit, including slide documents and widget registration
- enables `requiresModuleSystem` and documents the downstream module pattern
- makes `lake shake VersoSlides --keep-public` clean
- removes import-order dependence from the Markdown image warning expander

## Validation observed before closure

- clean Lake build: 414/414 jobs
- Shake import analysis: clean
- Lean configuration and standalone tests: 128 passed
- separate downstream-package build, incremental rebuild, and HTML render: passed
- TypeScript, jsconfig coverage, Prettier, and whitespace checks: passed
- GitHub's five initial CI checks: passed

Local repeated browser runs exposed nondeterministic Chromium interaction failures in varying tests; each failed case passed when rerun alone. No claim is made here that this flakiness is caused by, or predates, the module-system work.
